### PR TITLE
feat(skills): Add pf-token-auditor skill

### DIFF
--- a/plugins/pf-design-tokens/skills/pf-token-auditor/SKILL.md
+++ b/plugins/pf-design-tokens/skills/pf-token-auditor/SKILL.md
@@ -5,475 +5,131 @@ description: Validate and bridge Figma design styles to PatternFly 6 design toke
 
 # PatternFly Design Token Auditor & Bridge
 
-Audit designs (from Figma or raw CSS) against the PatternFly Token Architecture. Bridge Figma style outputs to PatternFly 6 composite and semantic tokens.
+Audit designs (from Figma or raw CSS) against the PatternFly token architecture. Bridge Figma style outputs to PatternFly 6 composite and semantic tokens.
+
+For token categories, unit mappings, theme files, and pairing tables, see [token-reference.md](token-reference.md).
 
 ## Workflow
 
 ### Step 1: Gather Input
 
-Determine the input type:
+**Figma URL provided?** Extract variables and design context using the Figma MCP (`get_variable_defs`, `get_design_context`). Track `data-node-id` attributes for elements that may need screenshots in findings.
 
-**Figma URL provided?** Use the Figma MCP:
-1. Call `get_variable_defs` via the Figma MCP with `nodeId` and `fileKey` to extract Figma variables.
-2. Call `get_design_context` to get code output and screenshot of the full frame.
-3. **Collect element node IDs.** The `get_design_context` output includes `data-node-id` attributes on each element. Track node IDs for any elements that will be flagged in findings — these will be used to capture element-level screenshots during the handoff step.
-4. **Identify the active theme and mode.** Figma variables have an "Extended Collection" (theme) and a mode applied to each frame. Determine which are active by inspecting the resolved values:
-   - If brand accent colors resolve to red (`#ee0000`), the **RedHat theme** is active (overrides in `tokens-redhat*.scss`).
-   - If brand accent colors resolve to blue (`#0066cc`), the **default (upstream)** theme is active.
-   - Mode is indicated by the variable collection mode: Light, Dark, Glass Light, Glass Dark, High Contrast Light, High Contrast Dark.
-   - Always validate token values against the **correct theme file**, not just `tokens-default.scss`.
+Identify the active theme and mode from resolved brand accent colors:
+- Red (`#ee0000`) → **RedHat theme**
+- Blue (`#0066cc`) → **default (upstream) theme**
 
-**Manual CSS / token values provided?** Parse the values directly. Ask which theme/mode if not specified.
+Always validate against the correct theme file (see Theme File Map in [token-reference.md](token-reference.md)).
+
+**Manual CSS / token values provided?** Parse directly. Ask which theme/mode if not specified.
 
 ### Step 2: Gather Token Descriptions
 
-For each token referenced in the design, look up its official usage description. These descriptions serve as authoritative evidence when validating or suggesting tokens.
-
-**Sources (in priority order):**
-
-1. **PatternFly docs** — Fetch from `https://www.patternfly.org/tokens/all-patternfly-tokens` or use the PatternFly Docs MCP (`searchPatternFlyDocs` with the token name). Each semantic token has a "Description" column explaining its intended use case.
-2. **Figma variable descriptions** — Figma variables may have descriptions set by the design team. These are visible in the `get_variable_defs` output or Figma's variable inspector.
-
-**How to use descriptions:**
-
-- When **validating** a token: cite the description to confirm correct usage. Example: `global/text/color/regular` — *"Use as the primary color for standard text, like heading/body copy."* — confirms it is appropriate for body text on a standard background.
-- When **flagging a mismatch**: cite the description to explain why the token is wrong. Example: `global/text/color/status/on-warning/default` — *"Use as the default color for text that is placed on a warning background color, like in banners."* — makes it clear this token is not appropriate for text on a glass/white background.
-- When **suggesting an alternative**: cite the replacement token's description to justify the recommendation. Example: recommend `global/text/color/on-brand/accent/default` because *"Use as the default color for text placed on a brand accent background"* matches the design's `brand/accent` background context.
-- Include the description inline in the finding, quoted and attributed. This makes findings self-documenting and removes ambiguity about why a token is or isn't appropriate.
+Look up each token's official usage description from [patternfly.org/tokens](https://www.patternfly.org/tokens/all-patternfly-tokens) or via the PatternFly MCP (`searchPatternFlyDocs`). Cite descriptions as evidence in every finding — when validating, flagging, or suggesting alternatives.
 
 ### Step 3: Classify Each Token
 
-For every design property extracted, classify it against the PatternFly token hierarchy:
+Classify every design property against the PatternFly token hierarchy:
 
 | Layer | Prefix Pattern | Verdict |
 |-------|---------------|---------|
-| Palette | `--pf-t--color--{hue}--{shade}` | REJECT - never use directly |
-| Base | `--pf-t--global--color--{concept}--{number}` | WARN - prefer semantic |
+| Palette | `--pf-t--color--{hue}--{shade}` | REJECT |
+| Base | `--pf-t--global--color--{concept}--{number}` | WARN |
 | Semantic | `--pf-t--global--{concept}--color--{context}--{state}` | PASS |
-| Component | `--pf-v6-c-{component}--{Property}` | PASS (if referencing semantic tokens) |
-| Raw hex/rgb | `#abc123`, `rgb(...)` | REJECT - must use a token |
+| Component | `--pf-v6-c-{component}--{Property}` | PASS |
+| Raw hex/rgb | `#abc123`, `rgb(...)` | REJECT |
 
 ### Step 4: Validate Naming
 
-Token names must follow: `--pf-t--global--{concept}--{property}--{modifier}--{state}`
-
-- **concept**: `spacer`, `font`, `background`, `border`, `box-shadow`, `icon`, `text`, `color`
-- **property**: `size`, `color`, `weight`, `width`, `radius`
-- **modifier**: `100`-`800`, `xs`-`4xl`, `sm`/`md`/`lg`, `primary`/`secondary`
-- **state**: `default`, `hover`, `clicked`, `disabled`
-
-Tokens are concept-based, never element-based:
-- WRONG: `--pf-t--global--h1--font--size`
-- RIGHT: `--pf-t--global--font--size--heading--h1`
+Token names follow: `--pf-t--global--{concept}--{property}--{modifier}--{state}`. Tokens are concept-based, never element-based (`font--size--heading--h1`, not `h1--font--size`).
 
 ### Step 5: Apply Validation Rules
 
-#### Rule 0 — Prefer Purpose-Specific Semantic Tokens Over Generic Scale Tokens
-When suggesting a token for a spacing, sizing, or any property, always cross-reference the **full set of purpose-specific semantic tokens** before falling back to a generic scale token. Purpose-specific tokens encode design intent and may be overridden independently in themes or component contexts.
+#### Rule 0 — Prefer Purpose-Specific Semantic Tokens
+Always cross-reference purpose-specific semantic tokens (see [token-reference.md](token-reference.md#purpose-specific-spacer-tokens)) before falling back to generic scale tokens. Purpose-specific tokens encode design intent and can be overridden independently.
 
-**Spacer example — gap between actions:**
-- WRONG: `--pf-t--global--spacer--md` (generic scale token, `1rem`)
-- RIGHT: `--pf-t--global--spacer--gap--action-to-action--default` (purpose-specific, `1rem`)
-
-Both resolve to `1rem`, but `action-to-action` communicates *why* the space exists and can be adjusted independently.
-
-**Semantic spacer gap tokens to cross-reference:**
-
-| Token | Value | Use when... |
-|---|---|---|
-| `spacer--gap--action-to-action--default` | `1rem` | Spacing between actions (buttons) in an action group |
-| `spacer--gap--action-to-action--plain` | `0.25rem` | Spacing between plain/icon actions |
-| `spacer--gap--control-to-control--default` | `0.25rem` | Spacing between controls (input groups, filter groups) |
-| `spacer--gap--text-to-element--default` | `0.5rem` | Spacing an icon or badge inline with text |
-| `spacer--gap--text-to-element--compact` | `0.25rem` | Compact variant of above |
-| `spacer--gap--group--horizontal` | `1rem` | Horizontal spacing between items in a group (label + input) |
-| `spacer--gap--group--vertical` | `0.5rem` | Vertical spacing between items in a group (label, input, helper text) |
-| `spacer--gap--group-to-group--horizontal--default` | `3rem` | Horizontal spacing between groups of elements |
-| `spacer--gap--group-to-group--vertical--default` | `1.5rem` | Vertical spacing between groups (stacked form groups) |
-
-Also check for purpose-specific **action**, **control**, and **inset** spacer tokens:
-
-| Token | Value | Use when... |
-|---|---|---|
-| `spacer--action--horizontal--default` | `1.5rem` | Horizontal padding inside a default action/button |
-| `spacer--action--horizontal--spacious` | `2rem` | Horizontal padding inside a CTA/display-lg action |
-| `spacer--action--horizontal--compact` | `1rem` | Horizontal padding inside a compact action |
-| `spacer--control--vertical--default` | `0.5rem` | Vertical padding inside controls |
-| `spacer--control--vertical--spacious` | `1rem` | Vertical padding inside CTA/display-lg controls |
-| `spacer--control--horizontal--default` | `1rem` | Horizontal padding inside controls (inputs, toggles) |
-
-Always cite the token's description to justify why it is the most appropriate match. Only suggest a generic scale token (`spacer--xs` through `spacer--4xl`) when no purpose-specific token exists for the context.
+- WRONG: `--pf-t--global--spacer--md` (generic)
+- RIGHT: `--pf-t--global--spacer--gap--action-to-action--default` (purpose-specific)
 
 #### Rule 1 — No Palette Tokens
-Palette tokens (`--pf-t--color--blue--50`) are raw values. Always map to semantic equivalents.
-
-```scss
-/* REJECT */  color: var(--pf-t--color--blue--50);
-/* ACCEPT */  color: var(--pf-t--global--text--color--link--default);
-```
+Palette tokens are raw values. Always map to semantic equivalents.
 
 #### Rule 2 — On-{Context} Foreground Matching
-Foreground elements (text, icons) must use `on-` tokens that **exactly match** the background context. This ensures correct contrast across all themes and modes (AA in default/glass, AAA in high-contrast).
-
-| Background Token | Text Token | Icon Token |
-|---|---|---|
-| `color--brand--default` | `text--color--on-brand--default` | `icon--color--on-brand--default` |
-| `color--brand--accent--default` | `text--color--on-brand--accent--default` | `icon--color--on-brand--accent--default` |
-| `color--brand--subtle--default` | `text--color--on-brand--subtle--default` | `icon--color--on-brand--subtle--default` |
-| `color--status--danger--default` | `text--color--status--on-danger--default` | `icon--color--status--on-danger--default` |
-| `color--status--success--default` | `text--color--status--on-success--default` | `icon--color--status--on-success--default` |
-| `color--status--warning--default` | `text--color--status--on-warning--default` | `icon--color--status--on-warning--default` |
-| `color--status--info--default` | `text--color--status--on-info--default` | `icon--color--status--on-info--default` |
-| `color--status--custom--default` | `text--color--status--on-custom--default` | `icon--color--status--on-custom--default` |
-| `background--color--disabled` | `text--color--on-disabled` | `icon--color--on-disabled` |
-| `background--color--highlight` | `text--color--on-highlight` | — |
-
-The `on-` prefix must match the background variant precisely. Using `on-brand--default` on a `brand--accent` background is WRONG — it may have correct contrast in the default theme but WILL FAIL in other themes (e.g., RedHat dark where `on-brand--accent` resolves to `--text--color--regular` instead of `--inverse`).
+Foreground elements (text, icons) on a colored background must use `on-` tokens that exactly match the background context. Using `on-brand--default` on a `brand--accent` background is wrong — it may pass in one theme but fail in others. See the full pairing table in [token-reference.md](token-reference.md#on-context-foreground-pairing).
 
 #### Rule 3 — Figma-to-CSS Unit Mapping
-Figma can only express sizes in pixels. PatternFly CSS tokens use `rem` for font sizes, icon sizes, spacers, and breakpoints, and unitless multipliers for line-heights. When validating Figma values against CSS token values, convert using `1rem = 16px` (base font size). Do NOT flag a unit difference as a value mismatch.
-
-**Font size:** Figma outputs `px`, CSS uses `rem`.
-
-| Figma (px) | CSS Token | CSS Value |
-|---|---|---|
-| `12` | `--pf-t--global--font--size--xs` | `0.75rem` |
-| `14` | `--pf-t--global--font--size--sm` | `0.875rem` |
-| `16` | `--pf-t--global--font--size--md` | `1rem` |
-| `18` | `--pf-t--global--font--size--lg` | `1.125rem` |
-| `20` | `--pf-t--global--font--size--xl` | `1.25rem` |
-| `24` | `--pf-t--global--font--size--2xl` | `1.5rem` |
-| `28` | `--pf-t--global--font--size--3xl` | `1.75rem` |
-| `36` | `--pf-t--global--font--size--4xl` | `2.25rem` |
-
-**Icon size:** Figma outputs `px`, CSS uses `rem`.
-
-| Figma (px) | CSS Token | CSS Value |
-|---|---|---|
-| `12` | `--pf-t--global--icon--size--sm` | `0.75rem` |
-| `14` | `--pf-t--global--icon--size--md` | `0.875rem` |
-| `16` | `--pf-t--global--icon--size--lg` | `1rem` |
-| `24` | `--pf-t--global--icon--size--xl` | `1.5rem` |
-| `56` | `--pf-t--global--icon--size--2xl` | `3.5rem` |
-| `96` | `--pf-t--global--icon--size--3xl` | `6rem` |
-
-**Breakpoint:** Figma outputs `px`, CSS uses `rem`.
-
-| Figma (px) | CSS Token | CSS Value |
-|---|---|---|
-| `576` | `--pf-t--global--breakpoint--sm` | `36rem` |
-| `768` | `--pf-t--global--breakpoint--md` | `48rem` |
-| `992` | `--pf-t--global--breakpoint--lg` | `62rem` |
-| `1200` | `--pf-t--global--breakpoint--xl` | `75rem` |
-| `1450` | `--pf-t--global--breakpoint--2xl` | `90.625rem` |
-
-**Line-height:** Figma outputs absolute `px`, CSS uses unitless multipliers. Only **two** line-height tokens exist:
-
-- `--pf-t--global--font--line-height--body` → `1.5`
-- `--pf-t--global--font--line-height--heading` → `1.3`
-
-All Figma `figma-only/body/*` line-height variables map to `--body`. All `figma-only/heading/*` map to `--heading`. Do NOT invent size-specific variants like `--body--lg` — they don't exist.
-
-See the full mapping tables in [token-reference.md](token-reference.md).
+Figma outputs `px`; PatternFly CSS uses `rem` (font/icon/spacer/breakpoint) and unitless multipliers (line-height). Convert with `1rem = 16px`. Do NOT flag unit differences as value mismatches. Only two line-height tokens exist (`--body` = 1.5, `--heading` = 1.3). See mapping tables in [token-reference.md](token-reference.md#figma-to-css-unit-mapping).
 
 #### Rule 4 — Composite Token Bridge
-When Figma outputs individual shadow or glass properties, recommend the single composite token.
-
-**Box Shadow** — Use composites from `tokens-local.scss`:
-
-```scss
-/* BEFORE: Figma outputs individual properties */
-box-shadow:
-  var(--pf-t--global--box-shadow--X--sm--default)
-  var(--pf-t--global--box-shadow--Y--sm--default)
-  var(--pf-t--global--box-shadow--blur--sm)
-  var(--pf-t--global--box-shadow--spread--sm--default)
-  var(--pf-t--global--box-shadow--color--sm--default);
-
-/* AFTER: Single composite token */
-box-shadow: var(--pf-t--global--box-shadow--sm);
-```
-
-Available composites: `--sm`, `--md`, `--lg` (each with `--top`, `--bottom`, `--left`, `--right` directional variants).
-
-**Glass Background** — Use composites from `tokens-local.scss`:
-
-```scss
-/* Composite glass tokens (use color-mix internally) */
-background-color: var(--pf-t--global--background--color--glass--primary--default);
-backdrop-filter: var(--pf-t--global--background--filter--glass--blur--primary);
-```
+When Figma outputs individual shadow or glass properties, recommend the single composite token (`--box-shadow--sm/md/lg`, `--background--color--glass--primary--default`). See composites in [token-reference.md](token-reference.md#box-shadow-composites-in-tokens-localscss).
 
 #### Rule 5 — Theme & Collection Awareness
-Validate against the correct theme. The Figma variable collection determines which CSS override file applies:
-
-**Default theme** (no extended collection):
-
-| Mode | Theme Class | Token File |
-|------|------------|------------|
-| Light | _(none)_ | `tokens-default.scss` |
-| Dark | `.pf-v6-theme-dark` | `tokens-dark.scss` |
-| HC Light | `.pf-v6-theme-high-contrast` | `tokens-highcontrast.scss` |
-| HC Dark | `.pf-v6-theme-high-contrast.pf-v6-theme-dark` | `tokens-highcontrast-dark.scss` |
-| Glass Light | `.pf-v6-theme-glass` | `tokens-glass.scss` |
-| Glass Dark | `.pf-v6-theme-glass.pf-v6-theme-dark` | `tokens-glass-dark.scss` |
-
-**RedHat theme** (extended collection = "Red Hat color tokens"):
-
-| Mode | Theme Class | Token File |
-|------|------------|------------|
-| Light | `.pf-v6-theme-redhat` | `tokens-redhat.scss` |
-| Dark | `.pf-v6-theme-redhat.pf-v6-theme-dark` | `tokens-redhat-dark.scss` |
-| HC Light | `.pf-v6-theme-redhat.pf-v6-theme-high-contrast` | `tokens-redhat-highcontrast.scss` |
-| HC Dark | `...high-contrast.pf-v6-theme-dark` | `tokens-redhat-highcontrast-dark.scss` |
-| Glass Light | `.pf-v6-theme-redhat.pf-v6-theme-glass` | `tokens-redhat-glass.scss` |
-| Glass Dark | `...glass.pf-v6-theme-dark` | `tokens-redhat-glass-dark.scss` |
-
-Key RedHat overrides: `--pf-t--global--color--brand--accent--default` points to `--accent--100` (red `#ee0000`) instead of `--brand--default` (blue).
-
-When drift-checking values (Rule 7), compare against the **active theme file**, not just `tokens-default.scss`.
+Validate against the correct theme. Determine theme from the Figma variable collection and mode. Compare values against the active theme file, not just `tokens-default.scss`. See the Theme File Map in [token-reference.md](token-reference.md#theme-file-map).
 
 #### Rule 6 — Contextual Token Pairing
-Tokens for sibling properties (background, border, text, icon) on the same element should share the same context. When a component uses a context-specific background, its border and foreground tokens should match that context:
-
-| Background Context | Border Token | Text/Icon Token |
-|---|---|---|
-| `glass--primary` | `border--color--glass--default` (if available) or `border--color--subtle` | `text--color--regular` |
-| `brand--default` | `border--color--brand--default` | `text--color--on-brand--default` |
-| `brand--accent` | `border--color--brand--accent--default` | `text--color--on-brand--accent--default` |
-| `status--danger` | `border--color--status--danger--default` | `text--color--status--on-danger--default` |
-
-If a context-specific border token does not yet exist in CSS (e.g., `border--color--glass--default`), flag it as an ESCALATION RECOMMENDED finding — the design intent is valid but the token may need to be proposed.
+Sibling properties (background, border, text, icon) on the same element should share the same context. If a context-specific token does not yet exist in CSS, flag as ESCALATION RECOMMENDED. See pairing table in [token-reference.md](token-reference.md#contextual-token-pairing).
 
 #### Rule 7 — Figma-to-Code Drift Detection
-Token values in the Figma source file may be updated before the CSS is regenerated. When a Figma variable value differs from its corresponding CSS token value:
-
-1. **Do NOT treat this as an error.** The Figma file is the upstream source of truth; `tokens-default.scss` is generated output.
-2. Flag it as **SYNC REQUIRED** — the CSS tokens need regeneration from the Figma source.
-3. Report both values so the team can confirm intent and trigger a token build.
-
-```markdown
-**SYNC REQUIRED:** `global/box-shadow/blur/sm`
-- Figma (source of truth): `6px`
-- CSS (generated, stale): `4px` (`--pf-t--global--box-shadow--blur--100`)
-- Action: Regenerate CSS tokens from Figma source, or confirm design intent with the team.
-```
+When a Figma variable value differs from its CSS token value, do NOT treat as an error. Figma is the upstream source of truth. Flag as **SYNC REQUIRED** and report both values.
 
 #### Rule 8 — Unbound Figma Properties
-When the generated code contains hardcoded values (raw `px`, hex, etc.) that are NOT backed by a Figma variable, this means the property was never bound to a variable in the Figma file. The Figma MCP cannot write changes back to designs.
-
-**Only suggest semantic tokens as replacements.** Never suggest base/numbered tokens (e.g., `border--radius--100`, `spacer--200`, `color--brand--100`). Always find the purpose-specific semantic token that matches the element's context (e.g., `border--radius--action--plain--default` instead of `border--radius--100`). If no semantic token exists for the property, state that explicitly and provide the closest semantic matches for reference.
-
-Report these as **FIGMA FIX NEEDED** with actionable instructions:
-
-```markdown
-**FIGMA FIX NEEDED:** Hardcoded `8px` gap
-- Node ID: `I10953:21650;10922:5688`
-- Property: Auto layout → Gap
-- Current: `8px` (hardcoded, no variable binding)
-- Fix: Bind to `global/spacer/sm`
-- How: Select the frame in Figma → right panel → Auto layout gap →
-  click the variable icon (⬡) → search `global/spacer/sm` → apply.
-```
+Hardcoded values not backed by a Figma variable need fixing in the Figma file. Only suggest semantic tokens as replacements — never base/numbered tokens. If no semantic token exists, state that explicitly and provide the closest matches.
 
 #### Rule 9 — Component Implementation Cross-Check
-When the Figma design represents a known PatternFly component or variant, cross-reference the design's token usage against the actual component SCSS implementation in the codebase. This catches two important scenarios:
-- **Unintentional error** — the designer applied the wrong token to an element.
-- **Design proposal** — the designer is intentionally suggesting a new or different token, which needs to go through the proposal process.
+When the design represents a known PatternFly component, compare the Figma token usage against the component's SCSS implementation. Flag differences as **IMPLEMENTATION DRIFT** — distinguish between likely errors and intentional design proposals. Include the component file path and selector for reference.
 
-**How to perform the cross-check:**
+### Step 6: Search Local Definitions
 
-1. **Identify the component.** From the Figma frame name, layer names, or CSS class output, determine which PatternFly component is being designed and which variant/modifier is active (e.g., `button` + `pf-m-secondary` + `pf-m-display-lg` = secondary CTA).
+Before escalating, search `src/patternfly/base/tokens/` (local, default, palette) and component SCSS for matching tokens. Use the PatternFly MCP for documentation lookups.
 
-2. **Locate the component SCSS.** Search `src/patternfly/components/{ComponentName}/{component}.scss` for the component's CSS custom property declarations. Each variant's token assignments are declared under their modifier class (e.g., `&.pf-m-secondary` within `&.pf-m-display-lg`).
+## Handoff Format
 
-3. **Extract the implementation tokens.** Build a map of property → token for the identified variant. Focus on:
-   - `--Color` (text color)
-   - `--BackgroundColor`
-   - `--BorderColor`
-   - `--BorderWidth`
-   - `--BorderRadius`
-   - `__icon--Color`
-   - Hover, clicked, and disabled states
-   - Padding, gap, font properties
+Each finding must include:
 
-4. **Compare Figma vs. implementation.** For each property in the Figma design, check if the applied Figma variable maps to the same semantic token as the component SCSS. Flag differences as **IMPLEMENTATION DRIFT**:
+- **Status label:** VALIDATED, COMPOSITE FOUND, CONTEXT MISMATCH, IMPLEMENTATION DRIFT, SYNC REQUIRED, FIGMA FIX NEEDED, or ESCALATION RECOMMENDED
+- **Element screenshot:** Call `get_screenshot` via the Figma MCP for the finding's element node. Present findings one at a time — call the screenshot, then immediately write the finding below it. Do NOT batch screenshots. Skip screenshots for validated tokens.
+- **Both token names:** Every table must include the Figma variable name AND the CSS token equivalent
+- **Token description:** Cited from patternfly.org or Figma, quoted inline
+- **Explanation:** Why the token is correct, incorrect, or being suggested — referencing the description
 
-   ```markdown
-   **IMPLEMENTATION DRIFT:** Secondary CTA background color
-   - Figma design: `global/background/color/primary/default` → `--pf-t--global--background--color--primary--default`
-   - Component SCSS: `transparent` (no BackgroundColor override; inherits base `transparent`)
-   - Component: `.pf-v6-c-button.pf-m-secondary.pf-m-display-lg`
-   - File: `src/patternfly/components/Button/button.scss` (lines 310-319)
-   - Assessment: The current implementation uses a transparent background for secondary CTA.
-     This may be a design proposal for a new filled secondary CTA, or an error.
-   - Action: Confirm with the design team whether this is an intentional proposal or a mistake.
-     If intentional, open a proposal: [GitHub Token Proposal](https://github.com/patternfly/design-tokens/issues/new)
-   ```
+### Finding table format
 
-5. **Assessment guidance.** Help the user understand the discrepancy:
-   - If the Figma design adds a property where the implementation has none (e.g., adding a background to a transparent button), flag it as a possible new proposal.
-   - If the Figma design uses a different token for a property that already has one (e.g., `text--color--regular` instead of `text--color--on-brand--default`), flag it as a likely error.
-   - If the Figma design omits a property that the implementation defines, note it as a possible simplification or oversight.
-   - Always include the component file path and line range for easy reference.
-
-**When to apply this rule:**
-- Always apply when the design clearly represents a specific PatternFly component (button, card, alert, modal, etc.).
-- Skip when the design is a custom/novel layout that doesn't map to an existing component.
-- When uncertain which component or variant is being designed, ask the user before proceeding.
-
-### Step 6: Search Local Definitions & Component Implementation
-
-Before escalating, search the codebase for a matching token and cross-reference the component:
-
-1. Search `src/patternfly/base/tokens/tokens-local.scss` for composites and temporary tokens.
-2. Search `src/patternfly/base/tokens/tokens-default.scss` for semantic tokens.
-3. **Cross-check component SCSS** (Rule 9): If the design maps to a known PatternFly component, read `src/patternfly/components/{ComponentName}/{component}.scss` and compare the variant's token assignments against the Figma design. Flag any differences as IMPLEMENTATION DRIFT.
-4. Use the PatternFly MCP: call `searchPatternFlyDocs` with the concept name.
-5. Call `usePatternFlyDocs` with `name: "Design tokens"` for documentation.
-
-### Step 7: Produce Handoff
-
-**Element-level screenshots:** Before writing the handoff, call `get_screenshot` via the Figma MCP for each element node ID that has a finding (IMPLEMENTATION DRIFT, CONTEXT MISMATCH, FIGMA FIX NEEDED, etc.). This gives the reader immediate visual context for each flagged issue. Include the screenshot image directly above or alongside the finding it relates to.
-
-Screenshot workflow:
-1. Gather the list of unique node IDs from findings (from `data-node-id` attributes collected in Step 1).
-2. **Present findings one at a time.** For each finding, call `get_screenshot` for that finding's element node, then immediately write the finding text below it. This ensures the screenshot appears visually inline with the finding it relates to.
-3. Do NOT batch all `get_screenshot` calls together — batching causes all images to appear grouped at the top, disconnected from their findings.
-4. For VALIDATED tokens, screenshots are not needed — only flagged findings get visual evidence.
-5. Composite, sync, and escalation findings that reference the full frame (not a specific element) can skip screenshots.
-
-**Token naming in all tables:** Every table that references a token — whether in findings or the validated tokens summary — must include **both** the Figma variable name (e.g., `global/text/color/regular`) **and** the corresponding CSS token (e.g., `--pf-t--global--text--color--regular`). Developers need the CSS token names for implementation; designers need the Figma variable names for source-of-truth context.
-
-Use this output format:
-
-```markdown
-### Token Handoff
-
-> **Status:** [VALIDATED | COMPOSITE FOUND | CONTEXT MISMATCH | IMPLEMENTATION DRIFT | SYNC REQUIRED | FIGMA FIX NEEDED | ESCALATION RECOMMENDED]
-
-<!-- Screenshot of the flagged element, captured via get_screenshot for the element's node ID -->
-
-#### Property: `{css-property}`
-**Figma Value:** `{raw value or Figma variable name}`
-**PatternFly Token:** `var({token-name})`
-**Token Description:** *"{official usage description from patternfly.org or Figma}"*
-**Why:** {Brief explanation of why this token is correct, incorrect, or being suggested — referencing the description}
-
-#### Implementation (if composite found)
-
-Before:
-\`\`\`scss
-{expanded properties}
-\`\`\`
-
-After:
-\`\`\`scss
-{single composite token}
-\`\`\`
-
-#### Figma-to-Code Drift (if sync required)
-
-| Source | Value |
-|--------|-------|
-| Figma (upstream) | `{figma value}` |
-| CSS (generated) | `{css value}` |
-| Action | Regenerate tokens or confirm intent |
-
-#### Context Mismatch (if on-color or contextual pairing is wrong)
-
-<!-- Screenshot of the element with the mismatched token -->
+Use tables for each finding type:
 
 | Detail | Value |
 |--------|-------|
-| Property | `{e.g., color}` |
-| Current token | `{Figma variable → CSS token}` |
-| — description | *"{usage description — explains the intended use, e.g., 'text on a warning background'}"* |
-| Recommended | `{correct CSS token}` |
-| — description | *"{usage description of the recommended token, e.g., 'text on a brand accent background'}"* |
-| Reason | The background context is `{context}`, so the foreground token must be `on-{context}` per the on-color principle |
+| Property | `{css property}` |
+| Current | `{Figma variable}` → `{CSS token}` |
+| — description | *"{official usage description}"* |
+| Recommended | `{correct token}` (if applicable) |
+| — description | *"{description of recommended token}"* |
+| Reason | `{brief explanation}` |
 
-#### Figma Fix (if unbound property found)
+For FIGMA FIX NEEDED findings, include: Node ID, Property, Current (hardcoded value), Bind to (Figma variable name), and How (brief Figma instructions).
 
-<!-- Screenshot of the element with the hardcoded value -->
+### Validated tokens summary
 
-| Detail | Value |
-|--------|-------|
-| Node ID | `{node-id}` |
-| Property | `{auto layout gap, fill, etc.}` |
-| Current | `{hardcoded value}` |
-| Bind to | `{figma variable name}` |
-| How | Select frame → right panel → property → click ⬡ → search variable → apply |
+End with a table of all passing tokens:
 
-#### Implementation Drift (if component cross-check finds a discrepancy)
-
-<!-- Screenshot of the Figma element being cross-checked -->
-
-| Detail | Value |
-|--------|-------|
-| Property | `{css property, e.g., background-color}` |
-| Figma design uses | `{Figma variable → CSS token}` |
-| — description | *"{usage description of the Figma token}"* |
-| Component SCSS uses | `{current token or value}` |
-| — description | *"{usage description of the SCSS token}"* |
-| Component selector | `{e.g., .pf-v6-c-button.pf-m-secondary.pf-m-display-lg}` |
-| File | `{path}` (lines `{start}-{end}`) |
-| Assessment | `{likely error / possible design proposal / component not yet updated}` |
-| Action | `{confirm with design team / open proposal / fix Figma}` |
-
-#### Multi-Mode Values
-
-| Mode | Value |
-|------|-------|
-| Light | `{value}` |
-| Dark | `{value}` |
-| Glass Light | `{value}` |
-| Glass Dark | `{value}` |
-| HC Light | `{value}` |
-| HC Dark | `{value}` |
-```
-
-## Quick Reference: Common Figma-to-Token Mappings
-
-| Figma Property | Raw Value | PatternFly Token |
-|---------------|-----------|-----------------|
-| Fill (white bg) | `#ffffff` | `--pf-t--global--background--color--primary--default` |
-| Fill (dark bg) | `#151515` | `--pf-t--global--background--color--primary--default` (dark theme) |
-| Text color | `#151515` | `--pf-t--global--text--color--regular` |
-| Subtle text | `#4d4d4d` | `--pf-t--global--text--color--subtle` |
-| Link color | `#0066cc` | `--pf-t--global--text--color--link--default` |
-| Border | `#e0e0e0` | `--pf-t--global--border--color--default` |
-| Border radius 4px | `4px` | `--pf-t--global--border--radius--100` |
-| Border radius 6px | `6px` | `--pf-t--global--border--radius--200` |
-| Small shadow | `0 1px 4px 0 rgba(41,41,41,.15)` | `--pf-t--global--box-shadow--sm` |
-| Medium shadow | (expanded) | `--pf-t--global--box-shadow--md` |
-| Large shadow | (expanded) | `--pf-t--global--box-shadow--lg` |
-| Spacing 4px | `4px` / `0.25rem` | `--pf-t--global--spacer--100` |
-| Spacing 8px | `8px` / `0.5rem` | `--pf-t--global--spacer--200` |
-| Spacing 16px | `16px` / `1rem` | `--pf-t--global--spacer--300` |
-| Spacing 24px | `24px` / `1.5rem` | `--pf-t--global--spacer--400` |
-| Font 12px | `0.75rem` | `--pf-t--global--font--size--xs` |
-| Font 14px | `0.875rem` | `--pf-t--global--font--size--sm` |
-| Font 16px | `1rem` | `--pf-t--global--font--size--md` |
-| Danger/error | `#b1380b` | `--pf-t--global--color--status--danger--default` |
-| Success | `#3d7317` | `--pf-t--global--color--status--success--default` |
-| Warning | `#ffcc17` | `--pf-t--global--color--status--warning--default` |
+| Property | Figma Variable | CSS Token | Verdict |
+|----------|---------------|-----------|---------|
+| {property} | `{figma var}` | `{css token}` | PASS |
 
 ## Escalation
 
-If no matching token exists after searching local definitions:
+If no matching token exists:
 
-1. State: "I've scanned the local token definitions and a direct match does not yet exist."
-2. Provide these links:
-   - **Community Slack:** [PatternFly Slack](https://join.slack.com/t/patternfly/shared_invite/zt-3spaxzss2-w1PPDTgvqENVqNvhPDQP~w)
-   - **Propose a Token:** [GitHub Token Proposal](https://github.com/patternfly/design-tokens/issues/new)
+1. State: "No direct match exists in the current token definitions."
+2. Provide:
+   - [PatternFly Slack](https://join.slack.com/t/patternfly/shared_invite/zt-3spaxzss2-w1PPDTgvqENVqNvhPDQP~w)
+   - [GitHub Token Proposal](https://github.com/patternfly/design-tokens/issues/new)
 
 ## Source Files
 
-All token definitions live in `src/patternfly/base/tokens/`:
-- `tokens-palette.scss` — raw color palette (hex values)
-- `tokens-default.scss` — light theme semantic tokens (generated)
-- `tokens-local.scss` — composite tokens, glass composites, temporary tokens
+Token definitions live in `src/patternfly/base/tokens/`:
+- `tokens-palette.scss` — raw color palette
+- `tokens-default.scss` — light theme semantic tokens
+- `tokens-local.scss` — composite tokens, glass composites
 - `tokens-dark.scss`, `tokens-glass.scss`, `tokens-highcontrast.scss` — theme overrides
 
 For the full token category reference, see [token-reference.md](token-reference.md).

--- a/plugins/pf-design-tokens/skills/pf-token-auditor/token-reference.md
+++ b/plugins/pf-design-tokens/skills/pf-token-auditor/token-reference.md
@@ -57,15 +57,6 @@ Line-height (**only two tokens exist**):
 - `--pf-t--global--font--line-height--body` → `1.5` (unitless)
 - `--pf-t--global--font--line-height--heading` → `1.3` (unitless)
 
-**Figma line-height mapping:** Figma expresses line-heights as absolute pixel values per font size. These all map to the two CSS tokens above:
-
-| Figma Variable | Pixel Value | Calculation | CSS Token |
-|---|---|---|---|
-| `global/font/line-height/figma-only/body/default` | `21px` | 14px × 1.5 | `--pf-t--global--font--line-height--body` |
-| `global/font/line-height/figma-only/body/large` | `24px` | 16px × 1.5 | `--pf-t--global--font--line-height--body` |
-| `global/font/line-height/figma-only/body/small` | `18px` | 12px × 1.5 | `--pf-t--global--font--line-height--body` |
-| `global/font/line-height/figma-only/heading/xs` | `24px` | heading context | `--pf-t--global--font--line-height--heading` |
-
 ### Icon Size
 ```
 --pf-t--global--icon--size--{scale}
@@ -105,6 +96,12 @@ Primitive components (in tokens-default.scss):
 - `--pf-t--global--box-shadow--blur--{scale}` (100-300)
 - `--pf-t--global--box-shadow--color--{scale}` (100-200)
 - `--pf-t--global--box-shadow--spread--{scale}` (100-400)
+
+When Figma outputs individual shadow properties, recommend the single composite:
+```scss
+/* Individual → Composite */
+box-shadow: var(--pf-t--global--box-shadow--sm); /* replaces X, Y, blur, spread, color primitives */
+```
 
 ### Glass (Composites in tokens-local.scss)
 ```
@@ -159,6 +156,135 @@ CSS uses `rem`, Figma outputs `px`:
 | `xl` | `500` | `75rem` | `1200` |
 | — | `550` | `80rem` | `1280` |
 | `2xl` | `600` | `90.625rem` | `1450` |
+
+---
+
+## Figma-to-CSS Unit Mapping
+
+Figma outputs `px`; PatternFly CSS uses `rem` (`1rem = 16px`). Do NOT flag unit differences as value mismatches.
+
+### Font Size
+
+| Figma (px) | CSS Token | CSS Value |
+|---|---|---|
+| `12` | `--pf-t--global--font--size--xs` | `0.75rem` |
+| `14` | `--pf-t--global--font--size--sm` | `0.875rem` |
+| `16` | `--pf-t--global--font--size--md` | `1rem` |
+| `18` | `--pf-t--global--font--size--lg` | `1.125rem` |
+| `20` | `--pf-t--global--font--size--xl` | `1.25rem` |
+| `24` | `--pf-t--global--font--size--2xl` | `1.5rem` |
+| `28` | `--pf-t--global--font--size--3xl` | `1.75rem` |
+| `36` | `--pf-t--global--font--size--4xl` | `2.25rem` |
+
+### Line-Height
+
+Figma outputs absolute `px`; CSS uses unitless multipliers. Only **two** line-height tokens exist:
+
+| Figma Variable | Pixel Value | Calculation | CSS Token |
+|---|---|---|---|
+| `global/font/line-height/figma-only/body/default` | `21px` | 14px × 1.5 | `--pf-t--global--font--line-height--body` |
+| `global/font/line-height/figma-only/body/large` | `24px` | 16px × 1.5 | `--pf-t--global--font--line-height--body` |
+| `global/font/line-height/figma-only/body/small` | `18px` | 12px × 1.5 | `--pf-t--global--font--line-height--body` |
+| `global/font/line-height/figma-only/heading/xs` | `24px` | heading context | `--pf-t--global--font--line-height--heading` |
+
+Do NOT invent size-specific variants like `--body--lg` — they don't exist.
+
+---
+
+## Purpose-Specific Spacer Tokens
+
+Always prefer purpose-specific tokens over generic scale tokens (`spacer--xs` through `spacer--4xl`).
+
+### Gap Tokens
+
+| Token | Value | Use when... |
+|---|---|---|
+| `spacer--gap--action-to-action--default` | `1rem` | Spacing between actions (buttons) in an action group |
+| `spacer--gap--action-to-action--plain` | `0.25rem` | Spacing between plain/icon actions |
+| `spacer--gap--control-to-control--default` | `0.25rem` | Spacing between controls (input groups, filter groups) |
+| `spacer--gap--text-to-element--default` | `0.5rem` | Spacing an icon or badge inline with text |
+| `spacer--gap--text-to-element--compact` | `0.25rem` | Compact variant of above |
+| `spacer--gap--group--horizontal` | `1rem` | Horizontal spacing between items in a group (label + input) |
+| `spacer--gap--group--vertical` | `0.5rem` | Vertical spacing between items in a group (label, input, helper text) |
+| `spacer--gap--group-to-group--horizontal--default` | `3rem` | Horizontal spacing between groups of elements |
+| `spacer--gap--group-to-group--vertical--default` | `1.5rem` | Vertical spacing between groups (stacked form groups) |
+
+### Action, Control, and Inset Tokens
+
+| Token | Value | Use when... |
+|---|---|---|
+| `spacer--action--horizontal--default` | `1.5rem` | Horizontal padding inside a default action/button |
+| `spacer--action--horizontal--spacious` | `2rem` | Horizontal padding inside a CTA/display-lg action |
+| `spacer--action--horizontal--compact` | `1rem` | Horizontal padding inside a compact action |
+| `spacer--control--vertical--default` | `0.5rem` | Vertical padding inside controls |
+| `spacer--control--vertical--spacious` | `1rem` | Vertical padding inside CTA/display-lg controls |
+| `spacer--control--horizontal--default` | `1rem` | Horizontal padding inside controls (inputs, toggles) |
+
+---
+
+## On-Context Foreground Pairing
+
+Foreground elements (text, icons) on a colored background must use `on-` tokens that exactly match the background context.
+
+| Background Token | Text Token | Icon Token |
+|---|---|---|
+| `color--brand--default` | `text--color--on-brand--default` | `icon--color--on-brand--default` |
+| `color--brand--accent--default` | `text--color--on-brand--accent--default` | `icon--color--on-brand--accent--default` |
+| `color--brand--subtle--default` | `text--color--on-brand--subtle--default` | `icon--color--on-brand--subtle--default` |
+| `color--status--danger--default` | `text--color--status--on-danger--default` | `icon--color--status--on-danger--default` |
+| `color--status--success--default` | `text--color--status--on-success--default` | `icon--color--status--on-success--default` |
+| `color--status--warning--default` | `text--color--status--on-warning--default` | `icon--color--status--on-warning--default` |
+| `color--status--info--default` | `text--color--status--on-info--default` | `icon--color--status--on-info--default` |
+| `color--status--custom--default` | `text--color--status--on-custom--default` | `icon--color--status--on-custom--default` |
+| `background--color--disabled` | `text--color--on-disabled` | `icon--color--on-disabled` |
+| `background--color--highlight` | `text--color--on-highlight` | — |
+
+The `on-` prefix must match the background variant precisely. Using `on-brand--default` on a `brand--accent` background may pass in one theme but will fail in others (e.g., RedHat dark where `on-brand--accent` resolves to `--text--color--regular` instead of `--inverse`).
+
+---
+
+## Contextual Token Pairing
+
+Sibling properties on the same element should share the same context:
+
+| Background Context | Border Token | Text/Icon Token |
+|---|---|---|
+| `glass--primary` | `border--color--glass--default` (if available) or `border--color--subtle` | `text--color--regular` |
+| `brand--default` | `border--color--brand--default` | `text--color--on-brand--default` |
+| `brand--accent` | `border--color--brand--accent--default` | `text--color--on-brand--accent--default` |
+| `status--danger` | `border--color--status--danger--default` | `text--color--status--on-danger--default` |
+
+If a context-specific border token does not yet exist in CSS, flag as ESCALATION RECOMMENDED.
+
+---
+
+## Common Figma-to-Token Mappings
+
+| Figma Property | Raw Value | PatternFly Token |
+|---------------|-----------|-----------------|
+| Fill (white bg) | `#ffffff` | `--pf-t--global--background--color--primary--default` |
+| Fill (dark bg) | `#151515` | `--pf-t--global--background--color--primary--default` (dark theme) |
+| Text color | `#151515` | `--pf-t--global--text--color--regular` |
+| Subtle text | `#4d4d4d` | `--pf-t--global--text--color--subtle` |
+| Link color | `#0066cc` | `--pf-t--global--text--color--link--default` |
+| Border | `#e0e0e0` | `--pf-t--global--border--color--default` |
+| Border radius 4px | `4px` | `--pf-t--global--border--radius--100` |
+| Border radius 6px | `6px` | `--pf-t--global--border--radius--200` |
+| Small shadow | `0 1px 4px 0 rgba(41,41,41,.15)` | `--pf-t--global--box-shadow--sm` |
+| Medium shadow | (expanded) | `--pf-t--global--box-shadow--md` |
+| Large shadow | (expanded) | `--pf-t--global--box-shadow--lg` |
+| Spacing 4px | `4px` / `0.25rem` | `--pf-t--global--spacer--100` |
+| Spacing 8px | `8px` / `0.5rem` | `--pf-t--global--spacer--200` |
+| Spacing 16px | `16px` / `1rem` | `--pf-t--global--spacer--300` |
+| Spacing 24px | `24px` / `1.5rem` | `--pf-t--global--spacer--400` |
+| Font 12px | `0.75rem` | `--pf-t--global--font--size--xs` |
+| Font 14px | `0.875rem` | `--pf-t--global--font--size--sm` |
+| Font 16px | `1rem` | `--pf-t--global--font--size--md` |
+| Danger/error | `#b1380b` | `--pf-t--global--color--status--danger--default` |
+| Success | `#3d7317` | `--pf-t--global--color--status--success--default` |
+| Warning | `#ffcc17` | `--pf-t--global--color--status--warning--default` |
+
+---
 
 ## RedHat Theme Key Overrides
 


### PR DESCRIPTION
## Summary

This skill solves the 'handoff gap' by allowing your ai agent to read styles & variables applied in live Figma layers via MCP and cross-reference them with the src/patternfly/base/tokens directory. It identifies incorrectly used base tokens/hex/px values and suggests contextually appropriate semantic token alternatives, translates pixel-based 'figma-only' variables into the corresponding code tokens as defined in our local tokens scss file, reconstructs complex CSS properties (like box-shadows) into their appropriate PatternFly composite tokens, and identifies any token discrepancies between the figma styles and existing component implementation.

- Adds new `pf-token-auditor` skill to `plugins/pf-react/skills/` for validating and bridging Figma design styles to PatternFly 6 design tokens
- Includes `SKILL.md` with full audit workflow (Figma variable extraction, token classification, naming validation, theme awareness, drift detection, and handoff generation)
- Includes `token-reference.md` with comprehensive PatternFly token category reference

## Test plan
- [ ] Verify `SKILL.md` renders correctly and relative link to `token-reference.md` resolves
- [ ] Confirm skill triggers on expected user mentions (e.g. "token audit", "Figma variables", "design tokens", "PF tokens")


Made with [Cursor](https://cursor.com)