### PR TITLE
feat(skill): add skill for updating org with PF release/prerelease

### DIFF
--- a/plugins/pf-workflow/skills/pf-org-version-update/SKILL.md
+++ b/plugins/pf-workflow/skills/pf-org-version-update/SKILL.md
@@ -159,7 +159,7 @@ The agent **does not** run `yarn install`, `yarn build`, `yarn serve`, or `yarn 
 
 5. When `yarn screenshots` has finished, stop the serve process.
 
-After providing the user with the steps to update screenshots, the SKill is done.
+After providing the user with the steps to update screenshots, the skill is done.
 
 ## Summary
 


### PR DESCRIPTION
Closes #17

Added a skill to assist in org repo updates for PF releases & prereleases. Designed to be run inside the org repo to properly find scripts and package files. 

The skill will:
- Use versions provided by the user, or fetch latest versions using org's internal script if none are provided.
- Update the site, framework, and root packages with the updated versions.
- Update the `versions.json` object array properly
- Provide the user with steps to regenerate screenshots for the release update.

I had attempted to get the skill to automatically run the build and screenshots, but ran into complications with cursor's sandbox permissions & build process timeouts, and didn't want to elevate any permissions so I changed it to only provide the user with directions.