### PR TITLE
Add bug-triage skill for preliminary issue triage

### DIFF
--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -62,7 +62,7 @@ Every skill or agent must live in a plugin. Pick the one that matches your skill
 
 | Plugin | Domain | Example skills | When to use |
 |--------|--------|----------------|-------------|
-| **pf-react** | React components, coding standards, testing | `component-suggest`, `feasibility-check`, `pf-upgrade`, `unit-test-generator` | Your skill helps write, test, review, or migrate PatternFly React code |
+| **pf-react** | React components, coding standards, testing | `component-suggest`, `feasibility-check`, `pf-upgrade`, `unit-test-generator`, `bug-triage` | Your skill helps write, test, review, triage, or migrate PatternFly React code |
 | **pf-design-tokens** | Design tokens, CSS variables, color contrast | `hex-scan`, `css-var-audit`, `token-contrast`, `suggest-tokens` | Your skill audits, validates, or suggests design tokens |
 | **pf-a11y** | Accessibility, WCAG, ARIA, screen readers | `audit`, `doc-scaffold` | Your skill checks, reports on, or documents accessibility |
 | **pf-figma** | Figma designs, design-to-code, assets | `design-review`, `design-diff`, `icon-id`, `brand-assets` | Your skill works with Figma designs, icons, or brand assets |
@@ -153,3 +153,4 @@ That's it. No frontmatter required. No code. No config. Just instructions in mar
 | `api-mock` | Generate mock data from a TypeScript interface |
 | `rename` | Suggest better names for variables and functions |
 | `pr-description` | Generate a clear PR description from a diff |
+| `bug-triage` | Preliminary triage of bug issues with fix suggestions and maintainer tagging |

--- a/plugins/pf-react/README.md
+++ b/plugins/pf-react/README.md
@@ -26,7 +26,33 @@ Skills and agents for PatternFly React development:
 - Unit test generation following Testing Library best practices
 - React and PatternFly-specific patterns and conventions
 
-Browse `skills/` for available skills (invoked as `/pf-react:<skill-name>`) and `agents/` for domain knowledge.
+### Skills
+
+Skills are tasks that produce a result.
+
+**Unit Test Generator** (`/pf-react:unit-test-generator`) — Generates a complete unit test file for a given React component, following Testing Library best practices.
+
+**Bug Triage** (`/pf-react:bug-triage`) — Performs preliminary triage of opened bug issues. Suggests what needs to be updated to fix the bug, provides context for assignees, and recommends the most appropriate maintainer to tag when the issue contains questions.
+
+### Agents
+
+Agents are domain knowledge the AI follows.
+
+**Coding Standards** — PatternFly React best practices:
+
+- Component composition patterns
+- PatternFly v6 styling standards
+- Design token usage
+- Accessibility requirements (WCAG 2.1 Level AA)
+- React and TypeScript best practices
+
+**Unit Test Standards** — Unit testing standards following Testing Library best practices:
+
+- User behavior testing over implementation details
+- Semantic query strategies
+- Proper mocking patterns
+- Accessibility testing
+- PatternFly-specific patterns
 
 ### PatternFly MCP Server
 
@@ -40,8 +66,14 @@ pf-react/
 │   └── plugin.json        # Plugin manifest + MCP server config
 ├── .cursor-plugin/
 │   └── plugin.json        # Identical copy for Cursor
-├── skills/                # Tasks that produce a result
-├── agents/                # Domain knowledge the AI follows
+├── agents/
+│   ├── coding-standards.md
+│   └── unit-test-standards.md
+├── skills/
+│   ├── bug-triage/
+│   │   └── SKILL.md
+│   └── unit-test-generator/
+│       └── SKILL.md
 └── README.md
 ```
 

--- a/plugins/pf-react/skills/bug-triage/SKILL.md
+++ b/plugins/pf-react/skills/bug-triage/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: bug-triage
+description: Performs preliminary triage of opened issues marked as bugs. Suggests what needs to be updated to fix reported bugs, provides context for assignees, and tags the most appropriate maintainer when the issue contains questions. Use when triaging bug issues, reviewing new bug reports, or preparing issues for assignment.
+---
+
+# Bug Triage
+
+Performs preliminary triage of opened issues labeled as bugs. Produces a structured triage summary with fix suggestions and maintainer recommendations.
+
+## Input
+
+The user provides an issue (title, body, labels, and optionally linked files or component names). The issue must be marked or labeled as a bug.
+
+## Triage Workflow
+
+### 1. Parse the Issue
+
+Extract from the issue:
+- **Summary** — One-sentence description of the bug
+- **Reproduction steps** — Are they clear and complete?
+- **Expected vs actual behavior** — Is the distinction stated?
+- **Environment** — Versions, browser, OS if mentioned
+- **Affected area** — Component, file path, or feature inferred from description
+
+### 2. Assess Completeness
+
+Flag if missing:
+- [ ] Reproduction steps
+- [ ] Expected vs actual behavior
+- [ ] Version/environment info
+- [ ] Minimal reproduction (code, sandbox, or repo link)
+
+Suggest what the reporter should add before the issue can be triaged effectively.
+
+### 3. Identify Fix Location
+
+Search the codebase for:
+- Component names, file paths, or imports mentioned in the issue
+- Related code in `packages/`, `src/`, or equivalent
+- Tests that might need updates
+- Documentation that might be wrong
+
+Suggest **what needs to be updated** to fix the bug:
+- Specific files or components
+- Likely root cause (logic, styling, accessibility, API usage)
+- Tests to add or modify
+- Any docs to update
+
+### 4. Determine Maintainer
+
+Find the most appropriate maintainer to tag when the issue **contains questions** (e.g., "Is this expected?", "How should we handle X?"):
+
+1. **Check CODEOWNERS** — If present, match issue paths to ownership:
+   - Map affected files/components to CODEOWNERS entries
+   - Tag the owner(s) for the most relevant path(s)
+
+2. **Check CONTRIBUTING.md / MAINTAINERS** — Look for maintainer lists, areas of responsibility, or "who to ask" sections.
+
+3. **Infer from codebase** — If no CODEOWNERS:
+   - Recent commits to affected files
+   - Component/package naming (e.g., `packages/react-table` → table maintainers)
+   - Comments or author info in relevant files
+
+4. **Fallback** — If unclear, suggest: "Tag @patternfly/react-core-maintainers" or the repo's default maintainer group.
+
+**Only suggest tagging when the issue explicitly asks a question** that requires maintainer input. Do not tag for straightforward bugs that just need implementation.
+
+For CODEOWNERS format and when-to-tag guidance, see [reference.md](reference.md).
+
+## Output Format
+
+Produce a triage comment or summary using this template:
+
+```markdown
+## Bug Triage Summary
+
+### Summary
+[One-sentence bug description]
+
+### Completeness
+- [ ] Reproduction steps clear
+- [ ] Expected vs actual stated
+- [ ] Environment/versions provided
+- [ ] Minimal reproduction available
+
+[If incomplete: List what the reporter should add]
+
+### Suggested Fix
+**Likely location:** [files, components, or packages]
+**Root cause:** [brief hypothesis]
+**Changes needed:**
+- [ ] [Specific change 1]
+- [ ] [Specific change 2]
+- [ ] [Tests to add/modify]
+- [ ] [Docs to update if applicable]
+
+### Context for Assignee
+[2–4 bullets: key files to look at, related patterns, similar past fixes, or docs to reference]
+
+### Maintainer Tag (if issue has questions)
+**Suggested:** @[username or team]
+**Reason:** [Why this maintainer — e.g., "Owns Table component per CODEOWNERS"]
+```
+
+## Rules
+
+- Be concise. Each section should be 1–3 sentences or bullets.
+- Only suggest maintainer tags when the issue **asks a question** requiring maintainer input.
+- If the codebase is unavailable, state what you would search for and produce a partial triage.
+- Use the repo's actual structure (e.g., `packages/react-core`, `packages/react-table`) when suggesting locations.

--- a/plugins/pf-react/skills/bug-triage/reference.md
+++ b/plugins/pf-react/skills/bug-triage/reference.md
@@ -1,0 +1,40 @@
+# Bug Triage Reference
+
+## Maintainer Lookup
+
+### CODEOWNERS Format
+
+GitHub CODEOWNERS uses path-based ownership:
+
+```
+# Default owners
+*       @org/team
+
+# Component-specific
+/packages/react-table/     @user1 @user2
+/packages/react-charts/    @user3
+/docs/                    @org/docs-team
+```
+
+Match the issue's affected files to the most specific path. Tag owners from the best-matching entry.
+
+### Common PatternFly Repos
+
+| Repo | Structure | Maintainer Sources |
+|------|-----------|---------------------|
+| patternfly-react | `packages/react-*/` | CODEOWNERS, package.json maintainers |
+| ai-helpers | `plugins/`, `docs/` | CONTRIBUTING.md, plugin READMEs |
+| patternfly | `src/` (CSS, tokens) | CODEOWNERS |
+
+### When to Tag
+
+Tag a maintainer only when the issue **asks a question** such as:
+- "Is this expected behavior?"
+- "Should we support X?"
+- "What's the recommended approach?"
+- "Is this a known limitation?"
+
+Do **not** tag for:
+- Straightforward bugs with clear reproduction
+- Issues that only need implementation
+- Questions the assignee can answer from docs


### PR DESCRIPTION
### Add bug-triage skill to pf-react plugin

**Summary**
Adds a new bug-triage skill to the pf-react plugin that performs preliminary triage of opened bug issues. It helps maintainers and contributors by suggesting what to change, giving context for assignees, and recommending which maintainer to tag when the issue asks a question.

**What it does**
Parse & assess — Extracts summary, reproduction steps, expected vs actual behavior, and environment info; flags missing information
Suggest fixes — Searches the codebase and suggests likely locations, root cause, and concrete changes (code, tests, docs)
Context for assignees — Points to relevant files, patterns, and docs
Maintainer tagging — Recommends the right maintainer to tag when the issue asks a question (e.g., "Is this expected?"), using CODEOWNERS or CONTRIBUTING when available
Why
Bug triage is time-consuming. This skill gives triagers and assignees a structured starting point so they can focus on implementation instead of discovery.

**How to use**
Invoke with `/pf-react:bug-triage` and provide the issue (title, body, labels, and optionally file paths or component names). The skill outputs a triage summary in a consistent format.
