### PR TITLE
Skill to debug semantic release issues when successful publication fails

### DIFF
--- a/.cursor/skills/semantic-release-troubleshooting/SKILL.md
+++ b/.cursor/skills/semantic-release-troubleshooting/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: semantic-release-troubleshooting
+description: >-
+  Diagnose and fix semantic-release issues when a specific version is not being
+  released. Use when semantic-release skips a version, fails to release, or when
+  troubleshooting after git push --force, squashed commits, permission errors,
+  or reference already exists.
+---
+
+# semantic-release Troubleshooting
+
+When a specific version is not being released, follow this diagnostic workflow.
+
+## 1. Identify the Problem
+
+Determine which scenario matches:
+
+| Symptom | Section |
+|---------|---------|
+| `You do not have permission to publish` (403) | → [Permission error](#permission-error) |
+| Release skipped; commits not counted | → [Squashed commits](#squashed-commits) |
+| `reference already exists` when pushing tag | → [Tag conflict](#tag-conflict) |
+| Release not found after `git push --force` | → [History rewrite recovery](#history-rewrite-recovery) |
+
+## 2. Permission Error
+
+**Cause:** npm registry auth or package name/ownership issues.
+
+**Verify package availability:**
+```bash
+npm install --global npm-name-cli
+npm-name <package-name>
+```
+
+**Fix:** Update `package.json` if name is taken, or use an [npm scope](https://docs.npmjs.com/misc/scope). Check [npm registry authentication](https://github.com/semantic-release/npm#npm-registry-authentication) and user [publish permissions](https://docs.npmjs.com/cli/team).
+
+## 3. Squashed Commits
+
+**Cause:** semantic-release uses [commit message convention](https://github.com/semantic-release/semantic-release#commit-message-format). Squashed commits often get non-compliant messages and are ignored.
+
+**Fix:** Rewrite the squashed commit message to follow the convention (e.g. `feat:`, `fix:`, `fix!:`, `BREAKING CHANGE:`). One squashed commit = one logical change; avoid combining unrelated features.
+
+## 4. Tag Conflict (`reference already exists`)
+
+**Cause:** A tag with the target version exists but is not in the current branch's history.
+
+**Diagnose:**
+```bash
+# Does the tag exist?
+git rev-list -1 <tag name>
+
+# Which branches contain this tag?
+git branch --contains <tag name>
+```
+
+**If the release was published:** Merge the commits from that release into your release branch.
+
+**If no published release:** Delete the tag:
+```bash
+git tag -d <tag name>
+git push origin :refs/tags/<tag name>
+```
+
+## 5. History Rewrite Recovery (after `git push --force`)
+
+**Cause:** `git push --force` rewrites history; tags and git notes tied to old commits become invalid.
+
+**Recovery steps** (in order):
+
+1. **Delete the orphaned tags** (remote then local):
+   ```bash
+   git push origin -d :<TAG NAME>   # e.g. git push origin -d :v2.0.0-beta.1
+   git tag -d <TAG NAME>
+   ```
+
+2. **Re-create the tags** on the new commit:
+   ```bash
+   git tag <TAG NAME> <COMMIT HASH>   # e.g. git tag v2.0.0-beta.1 abcdef0
+   ```
+
+3. **Re-create git notes** for each tag:
+   ```bash
+   # Beta/pre-release channel only
+   git notes --ref semantic-release add -f -m '{"channels":["beta"]}' <TAG NAME>
+
+   # Also on default channel (master/main)
+   git notes --ref semantic-release add -f -m '{"channels":[null,"beta"]}' <TAG NAME>
+   ```
+
+4. **Push the notes** (force required after rebase):
+   ```bash
+   git push --force origin refs/notes/semantic-release
+   ```
+
+## Reference
+
+Full documentation: [semantic-release Troubleshooting](https://semantic-release.gitbook.io/semantic-release/support/troubleshooting)

--- a/plugins/pf-workflow/skills/semantic-release-troubleshooting/SKILL.md
+++ b/plugins/pf-workflow/skills/semantic-release-troubleshooting/SKILL.md
@@ -32,7 +32,7 @@ npm install --global npm-name-cli
 npm-name <package-name>
 ```
 
-**Fix:** Update `package.json` if name is taken, or use an [npm scope](https://docs.npmjs.com/misc/scope). Check [npm registry authentication](https://github.com/semantic-release/npm#npm-registry-authentication) and user [publish permissions](https://docs.npmjs.com/cli/team).
+**Fix:** Update `package.json` if name is taken, or use an [npm scope](https://docs.npmjs.com/cli/v11/using-npm/scope/). Check [npm registry authentication](https://github.com/semantic-release/npm#npm-registry-authentication) and user [publish permissions](https://docs.npmjs.com/cli/v8/commands/npm-team/).
 
 ## 3. Squashed Commits
 
@@ -69,7 +69,7 @@ git push origin :refs/tags/<tag name>
 
 1. **Delete the orphaned tags** (remote then local):
    ```bash
-   git push origin -d :<TAG NAME>   # e.g. git push origin -d :v2.0.0-beta.1
+   git push origin -d <TAG NAME>    # e.g. git push origin -d v2.0.0-beta.1
    git tag -d <TAG NAME>
    ```
 

--- a/plugins/pf-workflow/skills/semantic-release-troubleshooting/SKILL.md
+++ b/plugins/pf-workflow/skills/semantic-release-troubleshooting/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   released. Use when semantic-release skips a version, fails to release, or when
   troubleshooting after git push --force, squashed commits, permission errors,
   or reference already exists.
+disable-model-invocation: true
 ---
 
 # semantic-release Troubleshooting
@@ -26,71 +27,39 @@ Determine which scenario matches:
 
 **Cause:** npm registry auth or package name/ownership issues.
 
-**Verify package availability:**
-```bash
-npm install --global npm-name-cli
-npm-name <package-name>
-```
+**Diagnosis:** Verify package name availability on the npm registry.
 
-**Fix:** Update `package.json` if name is taken, or use an [npm scope](https://docs.npmjs.com/cli/v11/using-npm/scope/). Check [npm registry authentication](https://github.com/semantic-release/npm#npm-registry-authentication) and user [publish permissions](https://docs.npmjs.com/cli/v8/commands/npm-team/).
+**Fix:** If the package name is taken, update `package.json` with a different name or use an [npm scope](https://docs.npmjs.com/cli/v11/using-npm/scope/). Ensure proper [npm registry authentication](https://github.com/semantic-release/npm#npm-registry-authentication) and confirm the user has [publish permissions](https://docs.npmjs.com/cli/v8/commands/npm-team/).
 
 ## 3. Squashed Commits
 
 **Cause:** semantic-release uses [commit message convention](https://github.com/semantic-release/semantic-release#commit-message-format). Squashed commits often get non-compliant messages and are ignored.
 
-**Fix:** Rewrite the squashed commit message to follow the convention (e.g. `feat:`, `fix:`, `fix!:`, `BREAKING CHANGE:`). One squashed commit = one logical change; avoid combining unrelated features.
+**Diagnosis:** Check that commit messages follow conventional commit format.
+
+**Fix:** Ensure commit messages follow the semantic-release convention with proper prefixes (`feat:`, `fix:`, `fix!:`, `BREAKING CHANGE:`). Each squashed commit should represent one logical change; avoid combining unrelated features. Rewrite non-compliant commit messages to match the required format.
 
 ## 4. Tag Conflict (`reference already exists`)
 
 **Cause:** A tag with the target version exists but is not in the current branch's history.
 
-**Diagnose:**
-```bash
-# Does the tag exist?
-git rev-list -1 <tag name>
+**Diagnosis:** Confirm whether the tag exists and identify which branches contain it.
 
-# Which branches contain this tag?
-git branch --contains <tag name>
-```
-
-**If the release was published:** Merge the commits from that release into your release branch.
-
-**If no published release:** Delete the tag:
-```bash
-git tag -d <tag name>
-git push origin :refs/tags/<tag name>
-```
+**Fix:**
+- If the release was published: Merge the commits from that release into your release branch.
+- If no published release: Delete the conflicting tag locally and from the remote repository.
 
 ## 5. History Rewrite Recovery (after `git push --force`)
 
 **Cause:** `git push --force` rewrites history; tags and git notes tied to old commits become invalid.
 
-**Recovery steps** (in order):
+**Diagnosis:** Identify orphaned tags and notes that point to old (rewritten) commits.
 
-1. **Delete the orphaned tags** (remote then local):
-   ```bash
-   git push origin -d <TAG NAME>    # e.g. git push origin -d v2.0.0-beta.1
-   git tag -d <TAG NAME>
-   ```
-
-2. **Re-create the tags** on the new commit:
-   ```bash
-   git tag <TAG NAME> <COMMIT HASH>   # e.g. git tag v2.0.0-beta.1 abcdef0
-   ```
-
-3. **Re-create git notes** for each tag:
-   ```bash
-   # Beta/pre-release channel only
-   git notes --ref semantic-release add -f -m '{"channels":["beta"]}' <TAG NAME>
-
-   # Also on default channel (master/main)
-   git notes --ref semantic-release add -f -m '{"channels":[null,"beta"]}' <TAG NAME>
-   ```
-
-4. **Push the notes** (force required after rebase):
-   ```bash
-   git push --force origin refs/notes/semantic-release
-   ```
+**Fix:** Recover in this order:
+1. Delete orphaned tags from both remote and local repositories
+2. Re-create tags pointing to the corresponding new commits
+3. Re-create git notes for each tag with appropriate channel configuration (e.g., `{"channels":["beta"]}` for beta channel only, or `{"channels":[null,"beta"]}` for both default and beta channels)
+4. Force push the updated notes to the remote repository
 
 ## Reference
 


### PR DESCRIPTION
Add skill to help debug issues when a specific release is not being published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive troubleshooting guide for semantic-release failures, including symptom identification tables and step-by-step remediation for permission issues, commit message compliance, tag conflicts, and recovery after history rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->