### PR TITLE
Update contributing guidelines/readmes

### DIFF
--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -100,7 +100,11 @@ Your skill becomes available as `/<plugin-name>:your-skill-name` for anyone who 
 
 **Good skills include examples.** Show what good output looks like AND what bad output looks like.
 
-**Good skills are short.** If your SKILL.md is over 200 lines, you're probably over-explaining. Say what you want, not how to think.
+**Good skills are short.** If your SKILL.md is over 200 lines, you're probably over-explaining. Say what you want, not how to think. The [Claude Code docs recommend under 500 lines](https://code.claude.com/docs/en/skills#add-supporting-files) as a ceiling — beyond that, move reference content into supporting files alongside your SKILL.md.
+
+**Good skills describe outcomes, not implementation.** Tell the AI what to accomplish, not how to do it. The AI already knows how to use `git`, `gh`, `grep`, and other tools — you don't need to spell out exact commands or multi-step conditional logic. A single sentence like "Check for issue templates locally, then via GitHub CLI, falling back to a blank issue" is better than 70 lines of bash scripts and if/else branches.
+
+**Good skills are tool-agnostic.** Skills in this repo work in both Claude Code and Cursor. Avoid referencing a specific tool in your instructions or examples (e.g., use "Assistant:" instead of "Claude:" in example conversations).
 
 ## What does a SKILL.md look like?
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Cursor can discover plugins from `.cursor-plugin/` directories. If you also have
 
 ## Available Plugins
 
-| Plugin | Description | Includes |
-|--------|-------------|----------|
-| **pf-react** | PatternFly React development standards | Coding standards agent, unit test standards agent, unit test generator skill, PatternFly MCP server |
-| **pf-design-tokens** | Design token auditing, validation, and migration | PatternFly MCP server |
-| **pf-a11y** | Accessibility auditing, reporting, and documentation | PatternFly MCP server |
-| **pf-figma** | Figma design review, diffing, and asset identification | PatternFly MCP server |
+| Plugin | Description |
+|--------|-------------|
+| **pf-react** | PatternFly React coding standards, testing, and development |
+| **pf-design-tokens** | Design token auditing, validation, and migration |
+| **pf-a11y** | Accessibility auditing, reporting, and documentation |
+| **pf-figma** | Figma design review, diffing, and asset identification |
 
-See each plugin's README for full documentation.
+Each plugin includes skills, agents, and a [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp). Browse each plugin's `skills/` and `agents/` directories for what's available.
 
 ## Repository Structure
 

--- a/plugins/pf-a11y/README.md
+++ b/plugins/pf-a11y/README.md
@@ -27,6 +27,8 @@ Skills and agents for PatternFly accessibility:
 - Accessibility documentation scaffolding
 - UI review for PatternFly conformance and deviations
 
+Browse `skills/` for available skills (invoked as `/pf-a11y:<skill-name>`) and `agents/` for domain knowledge.
+
 ### PatternFly MCP Server
 
 Skills and agents have access to the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) for looking up component documentation and accessibility guidelines. No manual configuration needed.

--- a/plugins/pf-design-tokens/README.md
+++ b/plugins/pf-design-tokens/README.md
@@ -28,6 +28,8 @@ Skills and agents for working with PatternFly design tokens:
 - Suggesting semantic tokens for common use cases
 - Mapping Figma-only token references to code equivalents
 
+Browse `skills/` for available skills (invoked as `/pf-design-tokens:<skill-name>`) and `agents/` for domain knowledge.
+
 ### PatternFly MCP Server
 
 Skills and agents have access to the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) for looking up component documentation and token references. No manual configuration needed.

--- a/plugins/pf-figma/README.md
+++ b/plugins/pf-figma/README.md
@@ -28,6 +28,8 @@ Skills and agents for the Figma-to-code workflow:
 - Summarizing implementation work from design updates
 - Identifying icons and brand assets
 
+Browse `skills/` for available skills (invoked as `/pf-figma:<skill-name>`) and `agents/` for domain knowledge.
+
 ### PatternFly MCP Server
 
 Skills and agents have access to the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) for looking up component documentation and design guidelines. No manual configuration needed.

--- a/plugins/pf-react/README.md
+++ b/plugins/pf-react/README.md
@@ -20,40 +20,17 @@ See the [root README](../../README.md) for Cursor installation options.
 
 ## What's Included
 
-### Skills
+Skills and agents for PatternFly React development:
 
-Skills are tasks that produce a result.
+- Coding standards enforcement for components, styling, accessibility, and TypeScript
+- Unit test generation following Testing Library best practices
+- React and PatternFly-specific patterns and conventions
 
-**Unit Test Generator** (`/pf-react:unit-test-generator`) — Generates a complete unit test file for a given React component, following Testing Library best practices.
-
-### Agents
-
-Agents are domain knowledge the AI follows.
-
-**Coding Standards** — PatternFly React best practices:
-
-- Component composition patterns
-- PatternFly v6 styling standards
-- Design token usage
-- Accessibility requirements (WCAG 2.1 Level AA)
-- React and TypeScript best practices
-
-**Unit Test Standards** — Unit testing standards following Testing Library best practices:
-
-- User behavior testing over implementation details
-- Semantic query strategies
-- Proper mocking patterns
-- Accessibility testing
-- PatternFly-specific patterns
+Browse `skills/` for available skills (invoked as `/pf-react:<skill-name>`) and `agents/` for domain knowledge.
 
 ### PatternFly MCP Server
 
-Both agents have access to the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) which provides:
-
-- **`searchPatternFlyDocs`** — Search for component documentation
-- **`usePatternFlyDocs`** — Get full docs and JSON schemas
-
-No manual configuration needed — the MCP server is defined in `plugin.json`.
+Skills and agents have access to the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) for looking up component documentation and prop schemas. No manual configuration needed.
 
 ## File Structure
 
@@ -63,12 +40,8 @@ pf-react/
 │   └── plugin.json        # Plugin manifest + MCP server config
 ├── .cursor-plugin/
 │   └── plugin.json        # Identical copy for Cursor
-├── agents/
-│   ├── coding-standards.md
-│   └── unit-test-standards.md
-├── skills/
-│   └── unit-test-generator/
-│       └── SKILL.md
+├── skills/                # Tasks that produce a result
+├── agents/                # Domain knowledge the AI follows
 └── README.md
 ```
 


### PR DESCRIPTION
A few minor changes to help make things clearer for contributors:

- Removed manual skill/agent listings from plugin READMEs so contributors don't need to update them
- Added guidelines for skill length (aim for under 200 lines, ceiling of 500) with link to Claude Code docs
- Added guidance on describing outcomes over implementation details, and using tool-agnostic language