### PR TITLE
feat(pf-design-tokens): add analyze-modifiers skill

### DIFF
--- a/plugins/pf-styling/skills/pf-analyze-modifiers/SKILL.md
+++ b/plugins/pf-styling/skills/pf-analyze-modifiers/SKILL.md
@@ -3,23 +3,19 @@ name: pf-analyze-modifiers
 description: Find, list, and summarize PatternFly component modifiers (pf-m- classes) across the codebase. Use when analyzing component styling patterns, documenting modifier usage, or auditing CSS consistency.
 ---
 
-# Analyze Modifiers Skill
+# Analyze Modifiers
 
-This skill helps you discover, understand, and document PatternFly modifier classes (pf-m- classes) across components.
+Discover, analyze, and document PatternFly modifier classes (`pf-m-*`) across component SCSS files. Search the codebase for modifier patterns, calculate usage statistics, and produce organized Markdown reports.
 
-## What This Skill Does
+## Input
 
-When invoked, the assistant will:
-1. Search through PatternFly component SCSS files to extract all modifier classes (pf-m-*)
-2. Analyze what each modifier does based on the CSS properties it applies
-3. Create a comprehensive summary organized by your preference
-4. Provide usage statistics and insights
+The user will specify a scope: all components (default), a specific component, a specific modifier, or a directory. If no scope is given, analyze all components.
 
-## Output Format
+## Output
 
-The default output should be a markdown file with:
+Write a Markdown file with:
 
-### Summary Section
+### Summary
 - Total unique modifiers found
 - Total components analyzed
 - Top 5 most frequently used modifiers (with count)
@@ -27,163 +23,72 @@ The default output should be a markdown file with:
 
 ### Modifier Listings
 
-**Default Organization: By Modifier (Alphabetical)**
+**Default: By Modifier (Alphabetical)**
 ```markdown
 ## pf-m-{modifier-name}
 - Component1
 - Component2
 ```
 
-**Alternative Organization: By Component**
+**Alternative: By Component**
 ```markdown
 ## Component Name
 - pf-m-modifier1
 - pf-m-modifier2
 ```
 
-## Usage Examples
-
-### Example 1: Analyze all modifiers
-```text
-User: /pf-styling:pf-analyze-modifiers
-```
-Expected: Create a complete listing of all modifiers across all components, organized alphabetically by modifier name.
-
-### Example 2: Analyze specific component
-```text
-User: /pf-styling:pf-analyze-modifiers for the Button component
-```
-Expected: List all modifiers used in the Button component with brief descriptions of what they do.
-
-### Example 3: Find modifier usage
-```text
-User: /pf-styling:pf-analyze-modifiers find where pf-m-disabled is used
-```
-Expected: List all components that use the pf-m-disabled modifier and show the CSS properties it applies in each context.
-
-### Example 4: Compare modifiers
-```text
-User: /pf-styling:pf-analyze-modifiers compare pf-m-expanded and pf-m-collapsed
-```
-Expected: Show which components use each modifier and explain the differences in behavior.
-
-## Instructions for the Assistant
-
-### Step 1: Determine Scope
-Identify what the user wants to analyze:
-- All components (default)
-- Specific component(s)
-- Specific modifier(s)
-- Components in a specific directory
-
-### Step 2: Search for Modifiers
-Locate all SCSS files containing component modifiers and extract modifier patterns from selectors and comments. For each modifier found, note the component name (derived from file path).
-
-### Step 3: Extract Modifier Details
-For each modifier, determine:
-- What CSS properties it modifies (if user asks for details)
-- Which elements it applies to (component root, specific child elements)
-- Any state changes it represents (expanded, disabled, current, etc.)
-- Responsive variants (on-sm, on-md, on-lg, on-xl, on-2xl)
-
-### Step 4: Organize Results
-Create a structured summary based on the user's request:
-- **By modifier**: Group components under each modifier name
-- **By component**: Group modifiers under each component name
-- **Statistical**: Show usage patterns, most common modifiers, etc.
-
-### Step 5: Generate Output
-Write results to a markdown file named appropriately:
+### File naming
 - `modifiers-listing.md` for complete listings
 - `{component-name}-modifiers.md` for component-specific analysis
 - `{modifier-name}-usage.md` for modifier-specific analysis
 
-## Output Quality Guidelines
+## Usage Examples
 
-### Be Comprehensive
-- Don't miss modifiers in nested selectors
-- Include responsive variants (pf-m-expandable-on-md, etc.)
-- Capture pseudo-state modifiers (:hover, :focus contexts)
-- Note element-specific modifiers (pf-v6-c-component__item.pf-m-current)
+### Analyze all modifiers
+```text
+User: /pf-styling:pf-analyze-modifiers
+```
 
-### Be Clear
-- Use consistent component names (Title, not title)
-- Alphabetize lists for easy scanning
-- Use proper Markdown formatting for readability
-- Include clear section headers
+### Analyze specific component
+```text
+User: /pf-styling:pf-analyze-modifiers for the Button component
+```
 
-### Provide Context
-In the summary section, highlight:
-- Patterns in modifier usage (many components use pf-m-disabled)
-- Outliers (Table has 67 modifiers vs average of 15)
-- Design system conventions (color modifiers: red, blue, green, orange, etc.)
+### Find modifier usage
+```text
+User: /pf-styling:pf-analyze-modifiers find where pf-m-disabled is used
+```
 
-## Common Modifier Categories
+### Compare modifiers
+```text
+User: /pf-styling:pf-analyze-modifiers compare pf-m-expanded and pf-m-collapsed
+```
 
-Help users understand patterns by grouping related modifiers:
+## Modifier Categories Reference
 
-### State Modifiers
-- pf-m-disabled, pf-m-active, pf-m-current, pf-m-selected, pf-m-hover, pf-m-focus
+### State
+pf-m-disabled, pf-m-active, pf-m-current, pf-m-selected, pf-m-hover, pf-m-focus
 
-### Size Modifiers
-- pf-m-sm, pf-m-md, pf-m-lg, pf-m-xl, pf-m-2xl, pf-m-compact
+### Size
+pf-m-sm, pf-m-md, pf-m-lg, pf-m-xl, pf-m-2xl, pf-m-compact
 
-### Layout Modifiers
-- pf-m-vertical, pf-m-horizontal, pf-m-inline, pf-m-block, pf-m-grid
+### Layout
+pf-m-vertical, pf-m-horizontal, pf-m-inline, pf-m-block, pf-m-grid
 
-### Visual Modifiers
-- pf-m-plain, pf-m-bordered, pf-m-raised, pf-m-filled, pf-m-outline
+### Visual
+pf-m-plain, pf-m-bordered, pf-m-raised, pf-m-filled, pf-m-outline
 
-### Color Modifiers
-- pf-m-red, pf-m-blue, pf-m-green, pf-m-orange, pf-m-purple, pf-m-teal, pf-m-yellow
+### Color
+pf-m-red, pf-m-blue, pf-m-green, pf-m-orange, pf-m-purple, pf-m-teal, pf-m-yellow
 
-### Responsive Modifiers
-- pf-m-{base}-on-sm, pf-m-{base}-on-md, pf-m-{base}-on-lg, pf-m-{base}-on-xl, pf-m-{base}-on-2xl
+### Responsive
+pf-m-{base}-on-sm, pf-m-{base}-on-md, pf-m-{base}-on-lg, pf-m-{base}-on-xl, pf-m-{base}-on-2xl
 
-### Semantic/Status Modifiers
-- pf-m-success, pf-m-warning, pf-m-danger, pf-m-info, pf-m-custom
+### Semantic/Status
+pf-m-success, pf-m-warning, pf-m-danger, pf-m-info, pf-m-custom
 
-## Edge Cases to Handle
+## Notes
 
-### Multiple Component Files
-Some components have multiple SCSS files (e.g., Table: table.scss, table-grid.scss, table-tree-view.scss). Consolidate these under a single component name.
-
-### Incomplete Modifier Patterns
-Some modifiers use dynamic values:
-- `pf-m-align-items-*` (various alignment values)
-- `pf-m-width-*` (percentage values)
-- `pf-m-inset-*` (spacing values)
-
-List these with asterisk notation and note they represent a pattern.
-
-### Deprecated or Internal Modifiers
-If you encounter modifiers that seem internal or temporary (e.g., pf-m-initializing-accent), still include them but note if they appear to be internal.
-
-## Error Handling
-
-If the search returns no results:
-- Verify the file path pattern is correct for the codebase structure
-- Check if components are organized differently
-- Suggest the user verify the working directory
-
-If the output is extremely large:
-- Offer to create separate files (one per component)
-- Provide summary statistics only
-- Allow filtering by component or modifier pattern
-
-## Success Criteria
-
-A successful execution should:
-1. Find all modifier classes in the specified scope
-2. Organize results clearly and logically
-3. Provide actionable statistics and insights
-4. Create a well-formatted markdown file
-5. Complete in a reasonable time (under 5 minutes for full codebase)
-
-## Related Skills
-
-This skill complements:
-- Component documentation generation
-- CSS audit and optimization
-- Accessibility review (modifier states)
-- Design token validation
+- Some components have multiple SCSS files (e.g., Table: table.scss, table-grid.scss, table-tree-view.scss) - consolidate under a single component name.
+- Some modifiers use dynamic values (`pf-m-align-items-*`, `pf-m-width-*`, `pf-m-inset-*`) - list with asterisk notation.
+- Include responsive variants, pseudo-state contexts, and element-specific modifiers (e.g., `pf-v6-c-component__item.pf-m-current`).


### PR DESCRIPTION
*Note: I believe this belongs in a new plugin for core/CSS, not in the design-tokens plugin, but since one doesn't exist I'll put it here for now.

## Summary
- Adds a new skill to discover, analyze, and document PatternFly modifier classes (pf-m-* classes)
- Searches through component SCSS files to extract all modifier usage
- Generates comprehensive markdown reports organized by modifier or by component
- Provides usage statistics and identifies patterns across the design system

## Use Cases
- Document all available modifiers for a component
- Find where a specific modifier is used across components
- Audit modifier patterns and identify inconsistencies
- Generate modifier reference documentation

## Test plan
- [ ] Run `/analyze-modifiers` on the PatternFly codebase
- [ ] Test component-specific analysis: `/analyze-modifiers for Button`
- [ ] Test modifier-specific search: `/analyze-modifiers find pf-m-disabled`
- [ ] Verify output includes responsive variants and nested modifiers
- [ ] Check that generated markdown files are properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skill to analyze PatternFly SCSS modifiers and produce Markdown reports (aggregate summaries, top counts, detailed listings by modifier or component).
  * Accepts scoped analysis (all, specific component, specific modifier, or directory) and supports pattern matching for dynamic modifiers.

* **Documentation**
  * Includes usage examples, output file naming conventions, handling of multiple SCSS files per component, and a reference list of modifier categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->