### PR TITLE
chore(skills): Update duplicate-epic skill to work with bugs and stories

### DIFF
--- a/plugins/issue-management/skills/duplicate-epic/SKILL.md
+++ b/plugins/issue-management/skills/duplicate-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duplicate-epic
-description: Duplicates an Atlassian Jira epic into the PatternFly (PF) project space, adds an "is duplicated by" link referencing the original, and assigns it as a child of a given feature. This allows the PatternFly team to trace Jira work items up a hierarchy in the product Jira project. Use when asked to "duplicate epic X for feature Y", clone a COST epic to PatternFly, or replicate a Jira epic under a PF feature.
+description: Duplicates an Atlassian Jira epic into the PatternFly (PF) project space, adds an "is duplicated by" link referencing the original, and assigns it as a child of a given feature. This allows the PatternFly team to trace Jira work items up a hierarchy in the product Jira project. Use when the command is "/duplicate-epic <issue> <feature>" where the first argument is any Jira issue key (Epic, Story, or Bug — the script resolves the parent epic automatically) and the second argument is the PF feature to assign the new epic to.
 disable-model-invocation: true
 ---
 
@@ -19,14 +19,23 @@ The script checks for both tools at startup and exits with a helpful message if 
 
 ## Input Parsing
 
-Accept issue identifiers as either bare keys or full URLs:
+The command takes exactly two positional arguments:
+
+| Position | Name | Description |
+|---|---|---|
+| `$1` | `issue` | Any Jira issue key or full URL — Epic, Story, Bug, etc. |
+| `$2` | `feature` | The PF feature key or full URL to assign the new epic to |
+
+Both bare keys and full URLs are accepted:
 
 | Input | Parsed key |
 |---|---|
-| `COST-7170` | `COST-7170` |
-| `https://redhat.atlassian.net/browse/COST-7170` | `COST-7170` |
-| `PF-3406` | `PF-3406` |
-| `https://redhat.atlassian.net/browse/PF-3406` | `PF-3406` |
+| `COST-7355` | `COST-7355` |
+| `https://redhat.atlassian.net/browse/COST-7355` | `COST-7355` |
+| `PF-3868` | `PF-3868` |
+| `https://redhat.atlassian.net/browse/PF-3868` | `PF-3868` |
+
+Pass `$1` and `$2` directly to the script — no further parsing required.
 
 ## Prerequisites
 
@@ -45,14 +54,16 @@ Run the script from the skill directory:
 
 ```bash
 cd $CLAUDE_SKILL_DIR
-bash scripts/duplicate_epic.sh <epic> <feature>
+bash scripts/duplicate_epic.sh <issue> <feature>
 ```
+
+The first argument (`issue`) may be an Epic, Story, Bug, or any other issue type. If it is not an Epic, the script automatically resolves its parent epic before cloning.
 
 **Examples:**
 
 ```bash
-bash scripts/duplicate_epic.sh COST-7170 PF-3406
-bash scripts/duplicate_epic.sh https://redhat.atlassian.net/browse/COST-7170 https://redhat.atlassian.net/browse/PF-3406
+bash scripts/duplicate_epic.sh COST-7355 PF-3868
+bash scripts/duplicate_epic.sh COST-7309 PF-3868   # story/bug — script walks up to parent epic automatically
 ```
 
 With inline credentials:
@@ -64,11 +75,13 @@ JIRA_USER_EMAIL="you@example.com" JIRA_API_TOKEN="your-token" \
 
 ## What the Script Does
 
-1. **Find existing clone** — checks the original epic's `Duplicate` issue links for any `PF-` issue; skips creation if found.
-2. **Clone** — if no clone exists, creates a new Epic in the `PF` project copying the summary, description, and labels.
-3. **Ensure "is duplicated by" link** — adds a `Duplicate` link so the new epic displays "is duplicated by {ORIGINAL}" in its linked work items; skips if already present.
-4. **Set parent and assignee** — assigns the new epic as a child of the given feature and assigns it to the current user (resolved automatically via the API token).
-5. **Display results** — prints clickable URLs for the feature, new epic, and original epic.
+1. **Resolve current user** — looks up the account ID for the authenticated user (used for the assignee field).
+2. **Resolve to an epic** — fetches the given issue. If it is not an `Epic` (e.g., it is a Story or Bug), the script walks up to its parent epic using `fields.parent` (next-gen projects) or `fields.customfield_10014` (classic epic link). Exits with an error if no parent epic can be found.
+3. **Find existing clone** — checks the resolved epic's `Duplicate` issue links for any `PF-` issue; skips creation if found.
+4. **Clone** — if no clone exists, creates a new Epic in the `PF` project copying the summary, description, and labels.
+5. **Ensure "is duplicated by" link** — adds a `Duplicate` link so the new epic displays "is duplicated by {ORIGINAL EPIC}" in its linked work items; skips if already present.
+6. **Set parent and assignee** — assigns the new epic as a child of the given feature and assigns it to the current user (resolved automatically via the API token).
+7. **Display results** — prints clickable URLs for the feature, new epic, and original epic.
 
 ## Output
 
@@ -78,4 +91,5 @@ After a successful run, display these URLs to the user:
 Feature:       https://redhat.atlassian.net/browse/PF-3406
 New Epic:      https://redhat.atlassian.net/browse/PF-XXXX
 Original Epic: https://redhat.atlassian.net/browse/COST-7170
+Input Issue:   https://redhat.atlassian.net/browse/COST-7309   ← only shown when input was not itself an epic
 ```

--- a/plugins/issue-management/skills/duplicate-epic/SKILL.md
+++ b/plugins/issue-management/skills/duplicate-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duplicate-epic
-description: Duplicates an Atlassian Jira epic into the PatternFly (PF) project space, adds an "is duplicated by" link referencing the original, and assigns it as a child of a given feature. This allows the PatternFly team to trace Jira work items up a hierarchy in the product Jira project. Use when the command is "/duplicate-epic <issue> <feature>" where the first argument is any Jira issue key (Epic, Story, or Bug — the script resolves the parent epic automatically) and the second argument is the PF feature to assign the new epic to.
+description: Use when `/duplicate-epic <issue> <feature>` should clone a Jira Epic, Story, or Bug into the PF project, resolve non-epic inputs to their parent epic, link back to the source, and attach the new epic to a PF feature.
 disable-model-invocation: true
 ---
 
@@ -78,7 +78,7 @@ JIRA_USER_EMAIL="you@example.com" JIRA_API_TOKEN="your-token" \
 1. **Resolve current user** — looks up the account ID for the authenticated user (used for the assignee field).
 2. **Resolve to an epic** — fetches the given issue. If it is not an `Epic` (e.g., it is a Story or Bug), the script walks up to its parent epic using `fields.parent` (next-gen projects) or `fields.customfield_10014` (classic epic link). Exits with an error if no parent epic can be found.
 3. **Find existing clone** — checks the resolved epic's `Duplicate` issue links for any `PF-` issue; skips creation if found.
-4. **Clone** — if no clone exists, creates a new Epic in the `PF` project copying the summary, description, and labels.
+4. **Clone** — if no clone exists, creates a new Epic in the `PF` project copying the summary and labels. The description is sanitized before cloning: `mediaSingle` and `media` nodes (embedded attachments) are stripped, so embedded images and file attachments will not appear in the PF copy.
 5. **Ensure "is duplicated by" link** — adds a `Duplicate` link so the new epic displays "is duplicated by {ORIGINAL EPIC}" in its linked work items; skips if already present.
 6. **Set parent and assignee** — assigns the new epic as a child of the given feature and assigns it to the current user (resolved automatically via the API token).
 7. **Display results** — prints clickable URLs for the feature, new epic, and original epic.

--- a/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
+++ b/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
@@ -112,8 +112,16 @@ ORIGINAL_ISSUE=$(api_request GET "issue/$ORIGINAL_KEY")
 
 ISSUE_TYPE=$(echo "$ORIGINAL_ISSUE" | jq -r '.fields.issuetype.name')
 INPUT_KEY="$ORIGINAL_KEY"
+DEPTH=0
+MAX_DEPTH=10
 
 while [[ "$ISSUE_TYPE" != "Epic" ]]; do
+  DEPTH=$((DEPTH + 1))
+  if [[ "$DEPTH" -gt "$MAX_DEPTH" ]]; then
+    echo "ERROR: Exceeded $MAX_DEPTH levels walking up the hierarchy from $INPUT_KEY — possible cycle or unexpectedly deep tree." >&2
+    exit 1
+  fi
+
   echo "$ORIGINAL_KEY is a $ISSUE_TYPE — walking up to parent..."
 
   # Try fields.parent (next-gen projects) then fields.customfield_10014 (classic epic link)
@@ -162,7 +170,7 @@ else
           assignee:    {accountId: $account_id}
         }
         + (if .fields.description != null then {
-           description: (.fields.description | .content = [.content[] | select(.type != "mediaSingle" and .type != "media")])
+           description: (.fields.description | walk(if type == "object" and .content? then .content = [.content[] | select(.type != "mediaSingle" and .type != "media")] else . end))
          } else {} end)
         + (if (.fields.labels | length) > 0  then {labels: .fields.labels}            else {} end)
       )

--- a/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
+++ b/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
@@ -141,6 +141,7 @@ fi
 # Step 4 — find or create PF clone
 echo "Checking for existing PF clone of $ORIGINAL_KEY..."
 
+CREATED_NEW_CLONE=0
 NEW_KEY=$(echo "$ORIGINAL_ISSUE" | jq -r --arg proj "${PF_PROJECT}-" \
   '[(.fields.issuelinks // [])[] | select(.type.name == "Duplicate") | .inwardIssue.key // empty | select(startswith($proj))] | first // empty')
 
@@ -169,6 +170,7 @@ else
 
   NEW_KEY=$(api_request POST "issue" "$PAYLOAD" | jq -r '.key')
   echo "Created: $NEW_KEY"
+  CREATED_NEW_CLONE=1
 fi
 
 # Step 5 — ensure "is duplicated by" link
@@ -186,11 +188,13 @@ else
     --arg new_key "$NEW_KEY" \
     --arg orig "$ORIGINAL_KEY" \
     '{type: {name: "Duplicate"}, inwardIssue: {key: $new_key}, outwardIssue: {key: $orig}}')
-  # Run in a subshell so a permission error here does not abort the rest of the script
-  if (api_request POST "issueLink" "$LINK_PAYLOAD" >/dev/null 2>&1); then
+  if api_request POST "issueLink" "$LINK_PAYLOAD" >/dev/null 2>&1; then
     echo "Link added"
-  else
+  elif [[ "$CREATED_NEW_CLONE" -eq 0 ]]; then
     echo "WARNING: Could not add 'is duplicated by' link (likely missing link-issue permission in the source project). Continuing..." >&2
+  else
+    echo "ERROR: Created $NEW_KEY but could not add the duplicate link; aborting to avoid future duplicate clones." >&2
+    exit 1
   fi
 fi
 

--- a/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
+++ b/plugins/issue-management/skills/duplicate-epic/scripts/duplicate_epic.sh
@@ -106,9 +106,40 @@ echo "Resolving current user..."
 ACCOUNT_ID=$(api_request GET "myself" | jq -r '.accountId')
 echo "Assignee account ID: $ACCOUNT_ID"
 
-# Step 2 — find or create PF clone
-echo "Checking for existing PF clone of $ORIGINAL_KEY..."
+# Step 2 — resolve to an epic (walk up the hierarchy until an Epic is found)
+echo "Fetching $ORIGINAL_KEY..."
 ORIGINAL_ISSUE=$(api_request GET "issue/$ORIGINAL_KEY")
+
+ISSUE_TYPE=$(echo "$ORIGINAL_ISSUE" | jq -r '.fields.issuetype.name')
+INPUT_KEY="$ORIGINAL_KEY"
+
+while [[ "$ISSUE_TYPE" != "Epic" ]]; do
+  echo "$ORIGINAL_KEY is a $ISSUE_TYPE — walking up to parent..."
+
+  # Try fields.parent (next-gen projects) then fields.customfield_10014 (classic epic link)
+  PARENT_KEY=$(echo "$ORIGINAL_ISSUE" | jq -r '
+    (.fields.parent.key // empty),
+    (.fields.customfield_10014 // empty)
+    | select(. != null and . != "")
+  ' | head -1)
+
+  if [[ -z "$PARENT_KEY" ]]; then
+    echo "ERROR: Reached the top of the hierarchy without finding an Epic (last checked: $ORIGINAL_KEY)" >&2
+    exit 1
+  fi
+
+  echo "Fetching $PARENT_KEY..."
+  ORIGINAL_ISSUE=$(api_request GET "issue/$PARENT_KEY")
+  ISSUE_TYPE=$(echo "$ORIGINAL_ISSUE" | jq -r '.fields.issuetype.name')
+  ORIGINAL_KEY="$PARENT_KEY"
+done
+
+if [[ "$ORIGINAL_KEY" != "$INPUT_KEY" ]]; then
+  echo "Resolved: using epic $ORIGINAL_KEY (original input was $INPUT_KEY)"
+fi
+
+# Step 4 — find or create PF clone
+echo "Checking for existing PF clone of $ORIGINAL_KEY..."
 
 NEW_KEY=$(echo "$ORIGINAL_ISSUE" | jq -r --arg proj "${PF_PROJECT}-" \
   '[(.fields.issuelinks // [])[] | select(.type.name == "Duplicate") | .inwardIssue.key // empty | select(startswith($proj))] | first // empty')
@@ -129,7 +160,9 @@ else
           issuetype:   {name: "Epic"},
           assignee:    {accountId: $account_id}
         }
-        + (if .fields.description != null then {description: .fields.description} else {} end)
+        + (if .fields.description != null then {
+           description: (.fields.description | .content = [.content[] | select(.type != "mediaSingle" and .type != "media")])
+         } else {} end)
         + (if (.fields.labels | length) > 0  then {labels: .fields.labels}            else {} end)
       )
     }')
@@ -138,7 +171,7 @@ else
   echo "Created: $NEW_KEY"
 fi
 
-# Step 3 — ensure "is duplicated by" link
+# Step 5 — ensure "is duplicated by" link
 echo "Checking for 'is duplicated by' link on $NEW_KEY..."
 NEW_ISSUE=$(api_request GET "issue/$NEW_KEY")
 
@@ -153,11 +186,15 @@ else
     --arg new_key "$NEW_KEY" \
     --arg orig "$ORIGINAL_KEY" \
     '{type: {name: "Duplicate"}, inwardIssue: {key: $new_key}, outwardIssue: {key: $orig}}')
-  api_request POST "issueLink" "$LINK_PAYLOAD" >/dev/null
-  echo "Link added"
+  # Run in a subshell so a permission error here does not abort the rest of the script
+  if (api_request POST "issueLink" "$LINK_PAYLOAD" >/dev/null 2>&1); then
+    echo "Link added"
+  else
+    echo "WARNING: Could not add 'is duplicated by' link (likely missing link-issue permission in the source project). Continuing..." >&2
+  fi
 fi
 
-# Step 4 — set parent and assignee
+# Step 6 — set parent and assignee
 echo "Assigning $NEW_KEY to current user and setting parent to $FEATURE_KEY..."
 UPDATE_PAYLOAD=$(jq -n \
   --arg feature "$FEATURE_KEY" \
@@ -166,9 +203,10 @@ UPDATE_PAYLOAD=$(jq -n \
 api_request PUT "issue/$NEW_KEY" "$UPDATE_PAYLOAD" >/dev/null
 echo "Updated"
 
-# Step 5 — display results
+# Step 7 — display results
 echo ""
 echo "Done!"
 echo "  Feature:       $JIRA_BASE_URL/browse/$FEATURE_KEY"
 echo "  New Epic:      $JIRA_BASE_URL/browse/$NEW_KEY"
 echo "  Original Epic: $JIRA_BASE_URL/browse/$ORIGINAL_KEY"
+[[ "$INPUT_KEY" != "$ORIGINAL_KEY" ]] && echo "  Input Issue:   $JIRA_BASE_URL/browse/$INPUT_KEY"


### PR DESCRIPTION
Updated duplicate-epic skill to work with different JIra bugs in addition to stories.

SKILL.md

- Updated the description frontmatter to clarify the skill accepts any issue type (Epic, Story, Bug) and uses the /duplicate-epic slash-command format
- Rewrote the Input Parsing section with a two-column positional arg table (position, name, description)
- Updated examples in the Workflow section to reflect that non-epic inputs are supported
- Expanded "What the Script Does" from 5 to 7 steps, adding "Resolve current user" and "Resolve to an epic"
- Added the Input Issue line to the Output section (only shown when the input was not itself an epic)

scripts/duplicate_epic.sh

- Added a while loop after fetching the input issue that walks up the hierarchy (fields.parent → fields.customfield_10014) until an Epic is found — allows passing a Story or Bug directly
- Tracks INPUT_KEY vs ORIGINAL_KEY so the resolved epic is shown separately in output
- Strips mediaSingle and media nodes from the description when cloning (avoids Jira API errors for embedded attachments)
- Wrapped the issueLink POST in a subshell so a permission error produces a WARNING instead of aborting the script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accepts any Jira issue type and auto-resolves to its parent Epic when needed.
  * Cloned Epics now strip embedded attachments/images from descriptions.

* **Bug Fixes**
  * Link-creation handling improved: failures emit warnings when no clone was made, but abort on unsafe partial states.
  * Output shows the original input URL only when it differed from the resolved Epic.

* **Documentation**
  * Updated docs and examples to reflect new inputs, workflow steps, and output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->