### PR TITLE
Added new prototype skill for grey scale support.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -78,6 +78,7 @@ React component development — coding standards, testing, and structure
 | `pf-import-checker` | Audits and fixes PatternFly import paths, with emphasis on charts, chatbot, and component-groups. |
 | `pf-library-test-writer` | Write unit tests for contributors to PatternFly libraries (patternfly-react, patternfly-chatbot, etc.), not for consumers of PatternFly components. |
 | `pf-project-scaffolder` | Scaffolds PatternFly React projects with PF6-safe dependencies, imports, and starter layout. |
+| `pf-prototype-mode` | Enable prototype mode for React apps (grayscale + banner) |
 | `pf-unit-test-generator` | Generate a comprehensive unit test file for a given React component |
 | `write-example-description` | Helps PatternFly developers write and refine example descriptions and demo descriptions for PatternFly.org. |
 

--- a/plugins/react/skills/pf-prototype-mode/SKILL.md
+++ b/plugins/react/skills/pf-prototype-mode/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pf-prototype-mode
+description: Enable prototype mode for React apps (grayscale + banner)
+---
+
+Enables prototype mode by adding a grayscale filter and prototype banner to a React application.
+
+## Step 1: Ask for Custom Message (Optional)
+
+Ask the user if they want a custom banner message. Default: "This application is a design prototype"
+
+## Step 2: Copy Template Files
+
+Copy the template files from this skill's `scripts/` directory to the user's project:
+
+1. **Read** `scripts/prototype.css` from this skill directory
+2. **Write** to `src/prototype.css` in the user's project
+3. **Read** `scripts/protoBanner.tsx` from this skill directory  
+4. **Write** to `src/components/ProtoBanner.tsx` in the user's project (create `src/components/` if needed)
+
+If a custom message was provided, replace the default message in `ProtoBanner.tsx` before writing it.
+
+## Step 3: Find and Update Entry Point
+
+1. **Find** the React entry point file using bash commands:
+   - Try: `src/index.tsx`, `src/index.jsx`, `index.tsx`, `index.jsx`
+   - Use `find` or check with `test -f` if needed
+   
+2. **Read** the entry point file
+
+3. **Check** if `import './prototype.css';` already exists
+   - If it exists: skip this step
+   - If not: **Edit** to add `import './prototype.css';` after existing imports
+
+## Step 4: Find and Update App Component
+
+1. **Find** the main App component file:
+   - Try: `src/App.tsx`, `src/App.jsx`, `App.tsx`, `App.jsx`
+   - Use `find` command if needed
+
+2. **Read** the App component file
+
+3. **Check** if ProtoBanner import already exists
+   - If not: **Edit** to add `import { ProtoBanner } from './components/ProtoBanner';` after existing imports
+
+4. **Check** if `<ProtoBanner` already exists in the JSX
+   - If not: **Edit** to insert `<ProtoBanner />` or `<ProtoBanner message="custom message" />` at the start of the return statement
+
+## Step 5: Verify Changes
+
+Confirm with the user:
+- ✅ prototype.css copied to src/
+- ✅ ProtoBanner.tsx copied to src/components/
+- ✅ CSS import added to entry point
+- ✅ ProtoBanner component added to App
+
+Tell the user that prototype mode is enabled and all UI will render in grayscale with a banner.
+
+## Notes
+
+- Always use Read tool before Edit tool
+- Use Edit tool (not Write) for modifying existing files
+- Check for existing imports/components to avoid duplicates
+- The grayscale filter applies to the entire HTML document via CSS
+- The ProtoBanner uses PatternFly's Banner component with `isSticky` prop

--- a/plugins/react/skills/pf-prototype-mode/SKILL.md
+++ b/plugins/react/skills/pf-prototype-mode/SKILL.md
@@ -15,7 +15,7 @@ Copy the template files from this skill's `scripts/` directory to the user's pro
 
 1. **Read** `scripts/prototype.css` from this skill directory
 2. **Write** to `src/prototype.css` in the user's project
-3. **Read** `scripts/protoBanner.tsx` from this skill directory  
+3. **Read** `scripts/ProtoBanner.tsx` from this skill directory  
 4. **Write** to `src/components/ProtoBanner.tsx` in the user's project (create `src/components/` if needed)
 
 If a custom message was provided, replace the default message in `ProtoBanner.tsx` before writing it.
@@ -62,12 +62,12 @@ Confirm with the user:
 - ✅ CSS import added to entry point
 - ✅ ProtoBanner component added to App
 
-Tell the user that prototype mode is enabled and all UI will render in grayscale with a banner.
+Tell the user that prototype mode is enabled. The banner includes a "Grayscale Mode" toggle switch to turn the grayscale filter on/off for prototyping.
 
 ## Notes
 
 - Always use Read tool before Edit tool
 - Use Edit tool (not Write) for modifying existing files
 - Check for existing imports/components to avoid duplicates
-- The grayscale filter applies to the entire HTML document via CSS
-- The ProtoBanner uses PatternFly's Banner component with `isSticky` prop
+- The grayscale filter applies when the `prototype-grayscale` class is on the `<html>` element (toggled via Switch in ProtoBanner)
+- The ProtoBanner uses PatternFly's Banner component with `isSticky` prop and includes a Switch to toggle grayscale mode

--- a/plugins/react/skills/pf-prototype-mode/SKILL.md
+++ b/plugins/react/skills/pf-prototype-mode/SKILL.md
@@ -28,9 +28,13 @@ If a custom message was provided, replace the default message in `ProtoBanner.ts
    
 2. **Read** the entry point file
 
-3. **Check** if `import './prototype.css';` already exists
+3. **Determine the correct import path** based on file location:
+   - If file is under `src/`: use `./prototype.css`
+   - If file is at root level: use `./src/prototype.css`
+
+4. **Check** if prototype CSS import already exists
    - If it exists: skip this step
-   - If not: **Edit** to add `import './prototype.css';` after existing imports
+   - If not: **Edit** to add the import (with correct path) after existing imports
 
 ## Step 4: Find and Update App Component
 
@@ -40,10 +44,14 @@ If a custom message was provided, replace the default message in `ProtoBanner.ts
 
 2. **Read** the App component file
 
-3. **Check** if ProtoBanner import already exists
-   - If not: **Edit** to add `import { ProtoBanner } from './components/ProtoBanner';` after existing imports
+3. **Determine the correct import path** based on file location:
+   - If file is under `src/`: use `./components/ProtoBanner`
+   - If file is at root level: use `./src/components/ProtoBanner`
 
-4. **Check** if `<ProtoBanner` already exists in the JSX
+4. **Check** if ProtoBanner import already exists
+   - If not: **Edit** to add the import (with correct path) after existing imports
+
+5. **Check** if `<ProtoBanner` already exists in the JSX
    - If not: **Edit** to insert `<ProtoBanner />` or `<ProtoBanner message="custom message" />` at the start of the return statement
 
 ## Step 5: Verify Changes

--- a/plugins/react/skills/pf-prototype-mode/SKILL.md
+++ b/plugins/react/skills/pf-prototype-mode/SKILL.md
@@ -15,10 +15,10 @@ Copy the template files from this skill's `scripts/` directory to the user's pro
 
 1. **Read** `scripts/prototype.css` from this skill directory
 2. **Write** to `src/prototype.css` in the user's project
-3. **Read** `scripts/ProtoBanner.tsx` from this skill directory  
-4. **Write** to `src/components/ProtoBanner.tsx` in the user's project (create `src/components/` if needed)
+3. **Read** `scripts/ProtoTypeBanner.tsx` from this skill directory  
+4. **Write** to `src/components/ProtoTypeBanner.tsx` in the user's project (create `src/components/` if needed)
 
-If a custom message was provided, replace the default message in `ProtoBanner.tsx` before writing it.
+If a custom message was provided, replace the default message in `ProtoTypeBanner.tsx` before writing it.
 
 ## Step 3: Find and Update Entry Point
 
@@ -45,22 +45,22 @@ If a custom message was provided, replace the default message in `ProtoBanner.ts
 2. **Read** the App component file
 
 3. **Determine the correct import path** based on file location:
-   - If file is under `src/`: use `./components/ProtoBanner`
-   - If file is at root level: use `./src/components/ProtoBanner`
+   - If file is under `src/`: use `./components/ProtoTypeBanner`
+   - If file is at root level: use `./src/components/ProtoTypeBanner`
 
-4. **Check** if ProtoBanner import already exists
+4. **Check** if ProtoTypeBanner import already exists
    - If not: **Edit** to add the import (with correct path) after existing imports
 
-5. **Check** if `<ProtoBanner` already exists in the JSX
-   - If not: **Edit** to insert `<ProtoBanner />` or `<ProtoBanner message="custom message" />` at the start of the return statement
+5. **Check** if `<ProtoTypeBanner` already exists in the JSX
+   - If not: **Edit** to insert `<ProtoTypeBanner />` or `<ProtoTypeBanner message="custom message" />` at the start of the return statement
 
 ## Step 5: Verify Changes
 
 Confirm with the user:
 - ✅ prototype.css copied to src/
-- ✅ ProtoBanner.tsx copied to src/components/
+- ✅ ProtoTypeBanner.tsx copied to src/components/
 - ✅ CSS import added to entry point
-- ✅ ProtoBanner component added to App
+- ✅ ProtoTypeBanner component added to App
 
 Tell the user that prototype mode is enabled. The banner includes a "Grayscale Mode" toggle switch to turn the grayscale filter on/off for prototyping.
 
@@ -69,5 +69,5 @@ Tell the user that prototype mode is enabled. The banner includes a "Grayscale M
 - Always use Read tool before Edit tool
 - Use Edit tool (not Write) for modifying existing files
 - Check for existing imports/components to avoid duplicates
-- The grayscale filter applies when the `prototype-grayscale` class is on the `<html>` element (toggled via Switch in ProtoBanner)
-- The ProtoBanner uses PatternFly's Banner component with `isSticky` prop and includes a Switch to toggle grayscale mode
+- The grayscale filter applies when the `prototype-grayscale` class is on the `<html>` element (toggled via Switch in ProtoTypeBanner)
+- The ProtoTypeBanner uses PatternFly's Banner component with `isSticky` prop and includes a Switch to toggle grayscale mode

--- a/plugins/react/skills/pf-prototype-mode/scripts/ProtoTypeBanner.tsx
+++ b/plugins/react/skills/pf-prototype-mode/scripts/ProtoTypeBanner.tsx
@@ -4,7 +4,7 @@ import { Banner, Bullseye, Flex, FlexItem, Switch } from "@patternfly/react-core
 export interface ProtoProps {
   message?: string;
 }
-const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a design prototype"}) => {
+const ProtoTypeBanner: React.FC<ProtoProps> = ({ message = "This application is a design prototype"}) => {
   const [isGrayscaleEnabled, setIsGrayscaleEnabled] = React.useState(true);
 
   React.useEffect(() => {
@@ -12,6 +12,7 @@ const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a de
     document.documentElement.classList.add('prototype-grayscale');
   }, []);
 
+  // Handles changes to grey scale.
   const handleToggle = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
     setIsGrayscaleEnabled(checked);
     if (checked) {
@@ -43,4 +44,4 @@ const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a de
   );
 };
 
-export { ProtoBanner };
+export { ProtoTypeBanner };

--- a/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
+++ b/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { Banner, Bullseye } from "@patternfly/react-core";
+
+export interface ProtoProps {
+  message?: string;
+}
+const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a design prototype"}) => {
+  return (
+    <Banner isSticky>
+      <Bullseye>
+        <strong>{message}</strong>
+      </Bullseye>
+    </Banner>
+  );
+};
+
+export { ProtoBanner };

--- a/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
+++ b/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
@@ -1,14 +1,43 @@
 import * as React from "react";
-import { Banner, Bullseye } from "@patternfly/react-core";
+import { Banner, Bullseye, Flex, FlexItem, Switch } from "@patternfly/react-core";
 
 export interface ProtoProps {
   message?: string;
 }
 const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a design prototype"}) => {
+  const [isGrayscaleEnabled, setIsGrayscaleEnabled] = React.useState(true);
+
+  React.useEffect(() => {
+    // Apply grayscale class on mount
+    document.documentElement.classList.add('prototype-grayscale');
+  }, []);
+
+  const handleToggle = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+    setIsGrayscaleEnabled(checked);
+    if (checked) {
+      document.documentElement.classList.add('prototype-grayscale');
+    } else {
+      document.documentElement.classList.remove('prototype-grayscale');
+    }
+  };
+
   return (
     <Banner isSticky>
       <Bullseye>
-        <strong>{message}</strong>
+        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsMd' }}>
+          <FlexItem>
+            <strong>{message}</strong>
+          </FlexItem>
+          <FlexItem>
+            <Switch
+              id="grayscale-toggle"
+              label="Grayscale"
+              isChecked={isGrayscaleEnabled}
+              onChange={handleToggle}
+              isReversed
+            />
+          </FlexItem>
+        </Flex>
       </Bullseye>
     </Banner>
   );

--- a/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
+++ b/plugins/react/skills/pf-prototype-mode/scripts/protoBanner.tsx
@@ -31,7 +31,7 @@ const ProtoBanner: React.FC<ProtoProps> = ({ message = "This application is a de
           <FlexItem>
             <Switch
               id="grayscale-toggle"
-              label="Grayscale"
+              label="Grayscale Mode"
               isChecked={isGrayscaleEnabled}
               onChange={handleToggle}
               isReversed

--- a/plugins/react/skills/pf-prototype-mode/scripts/prototype.css
+++ b/plugins/react/skills/pf-prototype-mode/scripts/prototype.css
@@ -1,0 +1,3 @@
+html {
+  filter: grayscale(100%);
+}

--- a/plugins/react/skills/pf-prototype-mode/scripts/prototype.css
+++ b/plugins/react/skills/pf-prototype-mode/scripts/prototype.css
@@ -1,3 +1,3 @@
-html {
+html.prototype-grayscale {
   filter: grayscale(100%);
 }


### PR DESCRIPTION
Added a skill to convert an app to a prototype so when you are doing design you can make identify the app as a prototype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prototype mode for React applications. Users can now enable a grayscale visual filter and display a prototype banner with a toggle switch. The feature includes support for custom banner messages and provides a visual indication that the app is in prototype mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->