### PR TITLE
docs(PF-4156): codify description formula and rewrite all skill descriptions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -35,8 +35,10 @@ reviews:
         Review against CONTRIBUTING-SKILLS.md. Agents provide domain knowledge
         the AI follows across all interactions in the plugin's area — they are
         not tasks that produce results (those are skills). Must be tool-agnostic.
-        Agent descriptions do NOT follow the skill description formula — do not
-        require action-verb lead-ins or "Use when" trigger contexts on agents.
+        Agent descriptions follow a different pattern than skills: [Domain noun]
+        [what it covers]. [Active when + context.] — no action-verb lead-in,
+        "Active when" instead of "Use when". Flag agents that use the skill
+        formula (action-verb lead-ins like "Define", "Standardize", "Generate").
     - path: "**/.claude-plugin/**"
       instructions: >
         Manifests must be identical in .claude-plugin/ and .cursor-plugin/.

--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -115,6 +115,68 @@ Use the `pf-` prefix on skill and agent names that are **PatternFly-specific**. 
 - Skill directory: `skills/pf-unit-test-generator/SKILL.md` with `name: pf-unit-test-generator`
 - Agent file: `agents/pf-coding-standards.md` with `name: pf-coding-standards`
 
+## Writing descriptions
+
+Every skill and agent needs a `description` in its frontmatter. This description is how the AI decides whether to load the skill — it's the single most important line in your SKILL.md.
+
+### Formula
+
+**[Action verb] [what it does]. [Use when + trigger contexts.]**
+
+### Rules
+
+1. **Start with an action verb** — Audit, Generate, Scan, Create, Validate, Find, Recommend. Not "Guide for," "Performs," "Enables," "A tool that."
+2. **One sentence for what it does** — the capability, not the implementation.
+3. **One sentence for when to use it** — "Use when" followed by 2-3 trigger scenarios separated by commas or "or."
+4. **No keyword lists** — the AI handles semantic matching. Don't pad with synonyms.
+5. **Front-load the key use case** — descriptions longer than 250 characters are truncated in the skill listing.
+
+### Examples
+
+**Good:**
+
+```yaml
+description: Audit focus traps, restoration, and screen reader announcements. Use when building modals, dialogs, or wizards that manage focus programmatically.
+```
+
+**Good:**
+
+```yaml
+description: Generate unit tests for React components. Use when creating new components, adding test coverage, or refactoring existing tests.
+```
+
+**Bad — starts with a weak verb:**
+
+```yaml
+description: A comprehensive guide for PatternFly component structure auditing and debugging.
+```
+
+**Bad — keyword stuffing:**
+
+```yaml
+description: Tool for testing, unit testing, component testing, React testing, PatternFly testing, jest testing.
+```
+
+### Agent descriptions
+
+Agents are domain knowledge, not tasks — their descriptions follow a different pattern.
+
+**[Domain noun] [what it covers]. [Active when + context.]**
+
+No action-verb lead-in. Use "Active when" instead of "Use when" — agents aren't invoked, they're contextually loaded.
+
+**Good:**
+
+```yaml
+description: PatternFly React coding standards — import patterns, component composition, token usage, and style conventions. Active when writing, reviewing, or refactoring PF React code.
+```
+
+**Bad — uses skill formula on an agent:**
+
+```yaml
+description: Define PatternFly React coding standards. Use when writing or reviewing PF React code.
+```
+
 ## Step 6: Contribute it
 
 Once you're happy with the skill:
@@ -135,7 +197,7 @@ For guidance on writing effective skills — structure, descriptions, examples, 
 
 In addition to the skill-creator guidance, skills in this repo must follow these rules:
 
-- **Frontmatter is required** with `name` and `description`. The `name` must match the directory name. The `description` should include trigger contexts (e.g., "Use when...") since the AI decides whether to load the skill based on the description alone. Front-load the key use case — descriptions longer than 250 characters are truncated in the skill listing.
+- **Frontmatter is required** with `name` and `description`. The `name` must match the directory name. See [Writing descriptions](#writing-descriptions) for the description formula.
 - Add `disable-model-invocation: true` if your skill has side effects (creates issues, posts comments, deploys)
 - **Describe outcomes, not implementation** — tell the AI what to accomplish, not how to do it. The AI already knows how to use `git`, `gh`, `grep`, etc.
 - **Skills must be tool-agnostic** — they run in both Claude Code and Cursor. Avoid referencing a specific tool (e.g., use "Assistant:" instead of "Claude:" in examples).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,17 +29,7 @@ Create a new plugin when your contribution represents a distinct domain that doe
 
 ### Plugin naming standard
 
-Plugin names must tell a user exactly what the plugin helps them do. Someone browsing the marketplace should understand what they're installing without clicking through.
-
-Ask: *"If someone sees this name in a list, do they know what they're installing?"*
-
-| Good | Why | Bad | Why |
-|------|-----|-----|-----|
-| `design-to-code` | Specific — bridges designs to PF code | `styling` | Vague — styling what? |
-| `migration` | Clear action — upgrades PF versions | `workflow` | Could mean anything |
-| `react` | Universal tech domain | `frontend` | Too broad |
-
-It's fine to create a plugin with only 1-2 skills if it represents a distinct domain. The taxonomy should reflect where the project is going, not just where it is today. Coordinate via an issue before creating a new plugin.
+Plugin names must tell a user what the plugin helps them do. See [CONTRIBUTING-SKILLS.md](CONTRIBUTING-SKILLS.md#plugin-naming-standard) for naming guidelines and examples. Coordinate via an issue before creating a new plugin.
 
 ### Steps
 
@@ -61,8 +51,10 @@ It's fine to create a plugin with only 1-2 skills if it represents a distinct do
 
 ### Skills vs Agents
 
-- **Skills** (`skills/your-skill/SKILL.md`) — tasks that produce a result. Use this for most contributions.
-- **Agents** (`agents/your-agent.md`) — domain knowledge the AI follows. Use for standards and guidelines.
+- **Skills** (`skills/your-skill/SKILL.md`) — tasks that produce a result. Most contributions are skills.
+- **Agents** (`agents/your-agent.md`) — domain knowledge the AI follows automatically.
+
+See [CONTRIBUTING-SKILLS.md](CONTRIBUTING-SKILLS.md#skill-vs-agent) for guidance on which to use.
 
 ## Adding Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,6 @@ If you discover a security vulnerability in this repository, please report it re
 **Do not open a public issue for security vulnerabilities.**
 
 - **GitHub:** Use [private vulnerability reporting](https://github.com/patternfly/ai-helpers/security/advisories/new)
-- **GitLab:** Open a confidential issue
 
 ## Scope
 

--- a/plugins/code-review/skills/summarize-pr-reviews/SKILL.md
+++ b/plugins/code-review/skills/summarize-pr-reviews/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize-pr-reviews
-description: "Summarize GitHub pull requests awaiting review from the current user. Use when the user asks to: (1) See their pending PR reviews, (2) Summarize PRs they need to review, (3) Get an overview of review requests, (4) Prioritize their code review queue, or (5) Understand what PRs are waiting for their review."
+description: Summarize GitHub pull requests awaiting your review with status, age, and priority. Use when triaging your review queue, prioritizing code reviews, or checking what PRs need attention.
 ---
 
 # Summarize My PR Review Queue

--- a/plugins/design-to-code/skills/figma-changes/SKILL.md
+++ b/plugins/design-to-code/skills/figma-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-changes
-description: Identify Figma design changes and generate code update checklists. Use when the user asks to "check Figma updates", "track design changes", "what changed in Figma", "create changelog from Figma", or "what code needs updating based on Figma".
+description: Diff Figma designs to identify what changed and generate code update checklists. Use when syncing code with updated designs or reviewing what changed between iterations. Requires Figma MCP.
 version: 3.1.0
 ---
 

--- a/plugins/design-to-code/skills/figma-icon-finder/SKILL.md
+++ b/plugins/design-to-code/skills/figma-icon-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-icon-finder
-description: Identifies PatternFly icons used in Figma mockups and provides the correct import statements for React components. Use when given a Figma screenshot or URL and the user needs to know which PatternFly icons to import.
+description: Identify PatternFly icons in Figma mockups and provide the correct React import statements. Use when implementing a design from Figma, verifying icon usage in a prototype, or finding the correct icon imports for React components. Requires Figma MCP.
 argument-hint: "[path/to/figma-screenshot.png] or [figma-url] or use @file for autocomplete"
 ---
 

--- a/plugins/design-to-code/skills/icon-finder/SKILL.md
+++ b/plugins/design-to-code/skills/icon-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icon-finder
-description: Find icons from the Red Hat Design System (@rhds/icons) by use case. Searches the Red Hat Icons demo site by keyword, returns matching icon names with a visual HTML preview for comparison. Use when the user asks to find an icon, search for an icon by purpose, pick an icon for a UI, or get icon options for a use case.
+description: Find Red Hat Design System icons (@rhds/icons) by keyword or use case with visual previews. Use when choosing an icon for a UI element or looking up available icons.
 ---
 
 # Icon Finder (Red Hat Icons)

--- a/plugins/design-to-code/skills/pf-ai-experience-patterns/SKILL.md
+++ b/plugins/design-to-code/skills/pf-ai-experience-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-ai-experience-patterns
-description: Apply Red Hat's AI design language for AI-powered demos and features. Use when user mentions AI experience, chatbots, virtual assistants, AI generation, or product prototypes. Proactively applies even without explicit request.
+description: Apply Red Hat's AI design language to AI-powered features — chatbots, assistants, generation UIs. Use when building AI experiences that should follow Red Hat brand and UX patterns.
 ---
 
 # Red Hat AI Experience Design Patterns

--- a/plugins/design-to-code/skills/pf-compliance-checker/SKILL.md
+++ b/plugins/design-to-code/skills/pf-compliance-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-compliance-checker
-description: Check Figma designs against PatternFly v6 design system standards. Use when a user provides a Figma URL and wants to validate compliance with PatternFly colors, typography, spacing, components, and UX patterns.
+description: Check Figma designs against PatternFly v6 standards for colors, typography, spacing, and component usage. Use when validating a design before handoff, auditing existing mockups for compliance, or reviewing design token usage. Requires Figma MCP.
 ---
 
 # PatternFly Compliance Checker

--- a/plugins/design-to-code/skills/pf-design-mode/SKILL.md
+++ b/plugins/design-to-code/skills/pf-design-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-design-mode
-description: Create and edit Figma design files using the Figma MCP workflow with PatternFly-approved libraries only. Use when the user asks to build, update, restyle, or restructure Figma frames/components and wants write operations.
+description: Create and edit Figma design files using PatternFly-approved component libraries. Use when building, updating, or restructuring Figma frames and components. Requires Figma MCP.
 disable-model-invocation: true
 ---
 

--- a/plugins/design-to-code/skills/pf-raw-colors-scan/SKILL.md
+++ b/plugins/design-to-code/skills/pf-raw-colors-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-raw-colors-scan
-description: "Analyze the provided code to find any raw color values assigned to styling properties. Flag these values as technical debt and suggest their replacement with design tokens."
+description: Find raw color values (hex, rgb, hsl) in code and suggest PatternFly design token replacements. Use when auditing stylesheets for hardcoded colors or enforcing token compliance.
 ---
 
 ### Role

--- a/plugins/design-to-code/skills/pf-token-auditor/SKILL.md
+++ b/plugins/design-to-code/skills/pf-token-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-token-auditor
-description: Validate and bridge Figma design styles to PatternFly 6 design tokens. Use when auditing Figma designs against PatternFly tokens, validating token naming, translating Figma styles to composite tokens, or when the user mentions "token validation", "token audit", "design tokens", "Figma audit", "Figma variables", "token bridge", or "PF tokens".
+description: Audit designs against the PatternFly 6 token architecture and bridge Figma styles to PF semantic tokens. Use when validating token usage, mapping Figma variables to PF tokens, or checking designs for token compliance.
 disable-model-invocation: true
 ---
 

--- a/plugins/migration/skills/pf-class-migration-scanner/SKILL.md
+++ b/plugins/migration/skills/pf-class-migration-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-class-migration-scanner
-description: Scans for legacy PatternFly class usage and recommends PF6-safe replacements. Use when modernizing older PatternFly codebases.
+description: Scan code for legacy PatternFly CSS classes and recommend PF6-safe replacements. Use when upgrading from PF4/PF5 or auditing a codebase for deprecated class names.
 ---
 
 # PF Class Migration Scanner

--- a/plugins/pf-workshop/skills/analytics-repo-pruning/SKILL.md
+++ b/plugins/pf-workshop/skills/analytics-repo-pruning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analytics-repo-pruning
-description: Flags archived or inactive Git repositories listed in PatternFly Analytics repos.json so entries can be pruned. Use when reviewing repos.json, auditing tracked codebases, or removing stale or archived repos from analytics.
+description: Flag archived or inactive repos in PatternFly Analytics repos.json for removal. Use when auditing tracked codebases or pruning stale entries from analytics.
 ---
 
 # Analytics repo pruning

--- a/plugins/pf-workshop/skills/css-var-analyzer/SKILL.md
+++ b/plugins/pf-workshop/skills/css-var-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: css-var-analyzer
-description: Analyze CSS custom property usage, redefinitions, and naming patterns in PatternFly SCSS components. Use when auditing --pf- variables, debugging missing definitions, tracing SCSS variable cascades, or finding unused CSS custom properties.
+description: Analyze --pf- CSS custom property usage and naming patterns in PatternFly SCSS. Use when auditing variable definitions, debugging missing tokens, or finding unused custom properties.
 ---
 
 # CSS Variable Analyzer

--- a/plugins/pf-workshop/skills/duplicate-epic/SKILL.md
+++ b/plugins/pf-workshop/skills/duplicate-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: duplicate-epic
-description: Use when `/duplicate-epic <issue> <feature>` should clone a Jira Epic, Story, or Bug into the PF project, resolve non-epic inputs to their parent epic, link back to the source, and attach the new epic to a PF feature.
+description: Clone a Jira epic from another project into the PF Jira space with back-links and feature attachment. Use when duplicating COST or cross-project epics into PF for tracking.
 disable-model-invocation: true
 ---
 

--- a/plugins/pf-workshop/skills/pf-analyze-modifiers/SKILL.md
+++ b/plugins/pf-workshop/skills/pf-analyze-modifiers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-analyze-modifiers
-description: Find, list, and summarize PatternFly component modifiers (pf-m- classes) across the codebase. Use when analyzing component styling patterns, documenting modifier usage, or auditing CSS consistency.
+description: Analyze PatternFly modifier class (pf-m-*) usage across SCSS files and generate usage reports. Use when documenting modifier patterns, auditing CSS consistency, or planning refactors.
 ---
 
 # Analyze Modifiers

--- a/plugins/pf-workshop/skills/pf-bug-triage/SKILL.md
+++ b/plugins/pf-workshop/skills/pf-bug-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-bug-triage
-description: Performs preliminary triage of opened issues marked as bugs. Suggests what needs to be updated to fix reported bugs, provides context for assignees, and tags the most appropriate maintainer when the issue contains questions. Use when triaging bug issues, reviewing new bug reports, or preparing issues for assignment.
+description: Triage PatternFly bug reports — assess completeness, suggest fixes, identify affected components, and recommend assignees. Use when reviewing new bug issues or preparing them for assignment.
 ---
 
 # Bug Triage

--- a/plugins/pf-workshop/skills/pf-create-issue/SKILL.md
+++ b/plugins/pf-workshop/skills/pf-create-issue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pf-create-issue
-description: Create GitHub issues for PatternFly repositories with smart templates, follow-up tracking, and duplicate detection.
+description: Create well-structured GitHub issues for PatternFly repositories with templates, follow-up tracking, and duplicate detection. Use when filing bugs, feature requests, or cross-repo follow-ups.
+disable-model-invocation: true
 ---
 
 # PatternFly Issue Creator

--- a/plugins/pf-workshop/skills/pf-org-version-update/SKILL.md
+++ b/plugins/pf-workshop/skills/pf-org-version-update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pf-org-version-update
-description: Updates the patternfly-org repo for a new PatternFly release or release candidate. Fetches or applies specified versions, updates package.json files and versions.json, and then provides the user with steps to run the build and regenerate screenshots locally. Use when preparing a PatternFly release, updating PF versions in this repo, or when the user asks to update patternfly-org for a new release.
+description: Update patternfly-org for a new PatternFly release — resolve versions, update package.json and versions.json, and provide build steps. Use when cutting a PF release or release candidate.
+disable-model-invocation: true
 ---
 
 # PatternFly Org Version Update

--- a/plugins/pf-workshop/skills/pf-tokens/SKILL.md
+++ b/plugins/pf-workshop/skills/pf-tokens/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pf-tokens
-description: Build CSS design tokens for PatternFly core and copy them to the PatternFly repository.
+description: Build CSS design tokens for PatternFly core and copy them to the PatternFly repository. Use when regenerating tokens after design changes or during release preparation.
+disable-model-invocation: true
 ---
 
 Build CSS design tokens for PatternFly core and move them to the PatternFly repository.

--- a/plugins/pf-workshop/skills/quarterly-initiative-report/SKILL.md
+++ b/plugins/pf-workshop/skills/quarterly-initiative-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarterly-initiative-report
-description: Generate comprehensive quarterly Jira status reports with progress tracking, RAG assessment, blocker identification, cross-project duplicate link analysis, and Q+1 recommendations. Use when generating quarterly reports, tracking initiative progress, or analyzing epic completion metrics across Jira projects with labels.
+description: Generate quarterly Jira status reports with RAG assessment, blocker tracking, and next-quarter recommendations. Use when preparing quarterly initiative reviews or tracking epic progress.
 disable-model-invocation: false
 ---
 

--- a/plugins/pf-workshop/skills/summarize-jira-issues/SKILL.md
+++ b/plugins/pf-workshop/skills/summarize-jira-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize-jira-issues
-description: "Summarize Jira sprint issues and contributions for the current user. Use when the user asks to: (1) See what's left in the sprint, (2) Summarize their assigned work, (3) Prioritize sprint tasks, (4) See issues they're contributing to, or (5) Understand what to work on next. Focuses on active sprint work first, then shows contributor roles and backlog."
+description: Summarize your current sprint workload from Jira — assigned issues, contributor roles, and priorities. Use when checking what's left in the sprint or deciding what to work on next.
 ---
 
 # Summarize My Jira Issues

--- a/plugins/pf-workshop/skills/write-example-description/SKILL.md
+++ b/plugins/pf-workshop/skills/write-example-description/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: write-example-description
-description: >-
-  Helps PatternFly developers write and refine example descriptions and demo
-  descriptions for PatternFly.org. Covers (1) component example MD files: prose
-  under each ### heading before the ts block in
-  packages/react-core/src/components/*/examples/*.md; (2) demo MD files: prose
-  under ## Demos / ### Demo name in packages/react-core/src/demos. Uses
-  PatternFly MCP for UX writing and content guidelines, suggests cross-links,
-  and asks the user to accept or request changes. Run only when the user asks.
+description: Write and refine example descriptions for PatternFly.org component and demo pages. Use when authoring or updating the prose in PatternFly example markdown files.
 ---
 
 # PatternFly example and demo descriptions

--- a/plugins/react/agents/pf-coding-standards.md
+++ b/plugins/react/agents/pf-coding-standards.md
@@ -1,6 +1,6 @@
 ---
 name: pf-coding-standards
-description: PatternFly React development standards. Use when writing, reviewing, or refactoring PatternFly React components, layouts, or styles.
+description: PatternFly React coding standards — import patterns, component composition, token usage, and style conventions. Active when writing, reviewing, or refactoring PF React code.
 ---
 
 # PatternFly React Development Standards

--- a/plugins/react/agents/pf-unit-test-standards.md
+++ b/plugins/react/agents/pf-unit-test-standards.md
@@ -1,6 +1,6 @@
 ---
 name: pf-unit-test-standards
-description: PatternFly React unit testing standards. Use when writing, reviewing, or modifying unit tests for PatternFly React components.
+description: PatternFly React unit testing standards — RTL patterns, mock boundaries, coverage expectations, and assertion style. Active when writing or reviewing unit tests for PF components.
 ---
 
 # PatternFly React Unit Test Standards

--- a/plugins/react/skills/pf-component-structure/SKILL.md
+++ b/plugins/react/skills/pf-component-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-component-structure
-description: Guide for PatternFly React component structure — audits, correct nesting, and layout debugging. Use when building with @patternfly/react-core or @patternfly/react-table, scanning code for hierarchy violations, or fixing spacing and alignment issues.
+description: Audit PatternFly React component nesting, wrapper hierarchies, and layout structure. Use when scanning for hierarchy violations or debugging spacing caused by missing wrapper components.
 ---
 
 Use this skill when you need a **structural audit** of PatternFly usage, or when fixing layouts caused by skipped wrappers. For day-to-day composition rules while writing UI, use the **component-structure-audit** agent (react plugin) or your client’s equivalent subagent for PatternFly structure.

--- a/plugins/react/skills/pf-import-checker/SKILL.md
+++ b/plugins/react/skills/pf-import-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-import-checker
-description: Audits and fixes PatternFly import paths, with emphasis on charts, chatbot, and component-groups. Use when imports fail or PatternFly modules are unresolved.
+description: Audit and fix invalid PatternFly import paths across packages. Use when imports fail, modules are unresolved, or after upgrading PatternFly versions.
 ---
 
 # PF Import Checker

--- a/plugins/react/skills/pf-prototype-mode/SKILL.md
+++ b/plugins/react/skills/pf-prototype-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-prototype-mode
-description: Enable prototype mode for React apps (grayscale + banner)
+description: Enable prototype mode for React apps with grayscale styling and a banner overlay. Use when demoing early concepts, presenting wireframes, or preventing stakeholders from fixating on visual polish.
 ---
 
 Enables prototype mode by adding a grayscale filter and prototype banner to a React application.

--- a/plugins/react/skills/pf-unit-test-generator/SKILL.md
+++ b/plugins/react/skills/pf-unit-test-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pf-unit-test-generator
-description: Generate a comprehensive unit test file for a given React component. Works for both consumer applications and component library contributions.
+description: Generate a unit test file for a React component using Testing Library. Use when adding test coverage to new or existing components.
 ---
 
 Generate a comprehensive unit test file for the given React component.


### PR DESCRIPTION
## Summary
- Adds a "Writing descriptions" section to CONTRIBUTING-SKILLS.md with a formula, rules, and good/bad examples for skill/agent frontmatter descriptions
- Rewrites all 26 skill/agent descriptions to follow the new formula: action verb + what it does + "Use when..." trigger contexts
- Removes duplicated content from CONTRIBUTING.md (plugin naming table, skills vs agents guidance) and replaces with links to CONTRIBUTING-SKILLS.md as the single source of truth
- Removes stale GitLab confidential issue line from SECURITY.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Writing descriptions" contributor guide with required description formula and examples.
  * Streamlined plugin creation guidance and clarified Skills vs. Agents decision guidance.
  * Simplified vulnerability reporting instructions in security docs.

* **Chores**
  * Updated description metadata across 25+ skills and agents for clearer, more specific usage guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/patternfly/ai-helpers/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->