### PR TITLE
feat(PF-4273): add eval for pf-unit-test-generator skill

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,6 +30,12 @@ reviews:
         user confirmation, access secrets/credentials, or access files outside
         the target project directory without explicit justification. Do not
         flag pf- prefix naming or markdown formatting.
+    - path: "plugins/*/skills/**"
+      instructions: >
+        Consumer-facing skills are expected to have an eval.yaml in
+        eval/<skill-name>/. If this PR adds or significantly modifies a
+        consumer skill and no corresponding eval exists, flag it as a
+        nitpick reminder.
     - path: "plugins/**/agents/*.md"
       instructions: >
         Review against CONTRIBUTING-SKILLS.md. Agents provide domain knowledge

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ prototypes/
 # Temporary files
 tmp/
 
+# Eval run output
+eval/runs/
+
 # Local Claude Code settings (user-specific)
 .claude/settings.local.json

--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -140,7 +140,7 @@ Every skill and agent needs a `description` in its frontmatter. This description
 2. **One sentence for what it does** — the capability, not the implementation.
 3. **One sentence for when to use it** — "Use when" followed by 2-3 trigger scenarios separated by commas or "or."
 4. **No keyword lists** — the AI handles semantic matching. Don't pad with synonyms.
-5. **Front-load the key use case** — descriptions longer than 250 characters are truncated in the skill listing.
+5. **Front-load the key use case** — AI tools [truncate skill descriptions](https://code.claude.com/docs/en/skills.md) to fit a context budget. Put the most important trigger context first so it survives truncation.
 
 ### Examples
 
@@ -234,7 +234,17 @@ In addition to the skill-creator guidance, skills in this repo must follow these
   command -v node >/dev/null 2>&1 || { echo "Error: This skill requires Node.js." >&2; exit 1; }
   ```
 - Use `$CLAUDE_SKILL_DIR` to reference scripts relative to the skill directory — it resolves to the directory containing SKILL.md regardless of where the repo is cloned
-- **Evals are optional** but recommended for skills with structured output or external system interactions — see the [skill-creator eval guide](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/skill-creator) for setup
+### Evals
+
+Evals are **expected** for consumer-facing skills. A skill graduating from `pf-workshop` to a consumer plugin should have an eval that proves its value.
+
+Write test cases that target what the skill **uniquely contributes** — don't test things the base model already knows without the skill loaded. See the [eval spike findings](https://docs.google.com/document/d/1Grgz-nbqVVZk0QzwzPb0Rk8m40kzvnAJjE4OD_zxlTk) for rationale on discriminating vs non-discriminating test cases.
+
+Evals use [agent-eval-harness](https://github.com/opendatahub-io/agent-eval-harness) and live in `eval/<skill-name>/eval.yaml` (not in the skill directory). See `eval/pf-unit-test-generator/eval.yaml` for a working example. To run evals locally, install the harness plugin:
+
+```bash
+claude plugin install agent-eval-harness@agent-eval-harness-dev
+```
 
 ### Security rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,4 @@ See [CONTRIBUTING-SKILLS.md](CONTRIBUTING-SKILLS.md#skill-vs-agent) for guidance
 - Keep documentation concise and AI-friendly
 - Don't hardcode a `model:` in agent frontmatter — it forces all users onto one model, overriding their preference
 - Use the `pf-` prefix on skill/agent names that are PatternFly-specific (see [CONTRIBUTING-SKILLS.md](CONTRIBUTING-SKILLS.md#naming-convention))
+- Consumer-facing skills are expected to have an eval — see [CONTRIBUTING-SKILLS.md](CONTRIBUTING-SKILLS.md#evals) for details

--- a/eval/pf-unit-test-generator/cases/consumer-with-children/ServiceCard.tsx
+++ b/eval/pf-unit-test-generator/cases/consumer-with-children/ServiceCard.tsx
@@ -1,0 +1,21 @@
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+import { StatusIcon } from './StatusIcon';
+import { LastUpdated } from './LastUpdated';
+
+interface ServiceCardProps {
+  name: string;
+  status: 'healthy' | 'degraded' | 'down';
+  lastChecked: Date;
+}
+
+const ServiceCard = ({ name, status, lastChecked }: ServiceCardProps) => (
+  <Card>
+    <CardTitle>{name}</CardTitle>
+    <CardBody>
+      <StatusIcon status={status} />
+      <LastUpdated date={lastChecked} />
+    </CardBody>
+  </Card>
+);
+
+export default ServiceCard;

--- a/eval/pf-unit-test-generator/cases/consumer-with-children/annotations.yaml
+++ b/eval/pf-unit-test-generator/cases/consumer-with-children/annotations.yaml
@@ -1,0 +1,1 @@
+context: consumer

--- a/eval/pf-unit-test-generator/cases/consumer-with-children/input.yaml
+++ b/eval/pf-unit-test-generator/cases/consumer-with-children/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Generate tests for this consumer application component that uses custom child components."
+fixture: ServiceCard.tsx

--- a/eval/pf-unit-test-generator/cases/library-tooltip/Tooltip.tsx
+++ b/eval/pf-unit-test-generator/cases/library-tooltip/Tooltip.tsx
@@ -1,0 +1,41 @@
+// packages/react-core/src/components/Tooltip/Tooltip.tsx
+import { ReactNode, useRef, useState } from 'react';
+import { TooltipContent } from './TooltipContent';
+import { TooltipArrow } from './TooltipArrow';
+
+export interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  className?: string;
+}
+
+export const Tooltip = ({
+  content,
+  children,
+  position = 'top',
+  className,
+  ...props
+}: TooltipProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div
+      ref={triggerRef}
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+      onFocus={() => setIsVisible(true)}
+      onBlur={() => setIsVisible(false)}
+      {...props}
+    >
+      {children}
+      {isVisible && (
+        <div className={`pf-v6-c-tooltip pf-m-${position} ${className || ''}`}>
+          <TooltipArrow />
+          <TooltipContent>{content}</TooltipContent>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/eval/pf-unit-test-generator/cases/library-tooltip/annotations.yaml
+++ b/eval/pf-unit-test-generator/cases/library-tooltip/annotations.yaml
@@ -1,0 +1,2 @@
+context: library
+rule: default

--- a/eval/pf-unit-test-generator/cases/library-tooltip/input.yaml
+++ b/eval/pf-unit-test-generator/cases/library-tooltip/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Generate tests for this component which lives inside the patternfly-react component library at packages/react-core/src/components/Tooltip/Tooltip.tsx."
+fixture: Tooltip.tsx

--- a/eval/pf-unit-test-generator/cases/library-wizard-orchestration/Wizard.tsx
+++ b/eval/pf-unit-test-generator/cases/library-wizard-orchestration/Wizard.tsx
@@ -1,0 +1,51 @@
+// packages/react-core/src/components/Wizard/Wizard.tsx
+import { ReactNode, useState } from 'react';
+import { WizardStep } from './WizardStep';
+import { WizardNav } from './WizardNav';
+import { WizardFooter } from './WizardFooter';
+
+export interface WizardProps {
+  steps: { name: string; component: ReactNode }[];
+  onSave: () => void;
+  onClose: () => void;
+  className?: string;
+}
+
+export const Wizard = ({
+  steps,
+  onSave,
+  onClose,
+  className,
+  ...props
+}: WizardProps) => {
+  const [activeStep, setActiveStep] = useState(0);
+  const isLastStep = activeStep === steps.length - 1;
+
+  const handleNext = () => {
+    if (isLastStep) {
+      onSave();
+    } else {
+      setActiveStep((prev) => prev + 1);
+    }
+  };
+
+  const handleBack = () => setActiveStep((prev) => Math.max(0, prev - 1));
+
+  return (
+    <div className={`pf-v6-c-wizard ${className || ''}`} {...props}>
+      <WizardNav
+        steps={steps.map((s) => s.name)}
+        activeStep={activeStep}
+        onStepClick={setActiveStep}
+      />
+      <WizardStep>{steps[activeStep].component}</WizardStep>
+      <WizardFooter
+        onNext={handleNext}
+        onBack={handleBack}
+        onClose={onClose}
+        isBackDisabled={activeStep === 0}
+        nextLabel={isLastStep ? 'Save' : 'Next'}
+      />
+    </div>
+  );
+};

--- a/eval/pf-unit-test-generator/cases/library-wizard-orchestration/annotations.yaml
+++ b/eval/pf-unit-test-generator/cases/library-wizard-orchestration/annotations.yaml
@@ -1,0 +1,2 @@
+context: library
+rule: orchestration-exception

--- a/eval/pf-unit-test-generator/cases/library-wizard-orchestration/input.yaml
+++ b/eval/pf-unit-test-generator/cases/library-wizard-orchestration/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Generate tests for this component which lives inside the patternfly-react component library at packages/react-core/src/components/Wizard/Wizard.tsx. Note: the parent-child interaction between Wizard and its children (WizardNav, WizardStep, WizardFooter) IS the behavior being tested — the Wizard orchestrates navigation across steps."
+fixture: Wizard.tsx

--- a/eval/pf-unit-test-generator/eval.yaml
+++ b/eval/pf-unit-test-generator/eval.yaml
@@ -1,0 +1,106 @@
+name: pf-unit-test-generator-eval
+description: Evaluate pf-unit-test-generator's consumer vs library context detection
+
+skill: react:pf-unit-test-generator
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-6
+  judge: claude-sonnet-4-6
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: prompt field with a realistic user request
+    - annotations.yaml: context (consumer/library) and rule for conditional judges
+    - A .tsx fixture file the prompt references
+
+outputs:
+  - path: artifacts
+    schema: |
+      The skill generates a .test.tsx file. Judges check both
+      conversation text and collected file artifacts.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: has_test_content
+    description: Sanity check — output contains render() and expect() calls
+    check: |
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      if "render(" not in text or "expect(" not in text:
+          return False, "Output doesn't look like a test file"
+      return True, "Contains render and expect calls"
+
+  - name: consumer_no_child_mocking
+    description: Consumer components should NOT mock child components
+    if: "annotations.get('context') == 'consumer'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      mock_pattern = re.compile(
+          r'(jest\.mock|vi\.mock|jest\.spyOn)\s*\([^)]*?(StatusIcon|LastUpdated)'
+      )
+      if mock_pattern.search(text):
+          return False, "Consumer children should not be mocked"
+      return True, "No child mocking — correct consumer behavior"
+
+  - name: library_mocks_children
+    description: Library components should mock sibling modules for unit isolation
+    if: "annotations.get('context') == 'library' and annotations.get('rule') == 'default'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      mock_pattern = re.compile(
+          r"(jest\.mock|vi\.mock)\s*\(\s*['\"]\.\.?/"
+      )
+      if not mock_pattern.search(text):
+          return False, "Library should mock sibling modules for unit isolation"
+      return True, "Relative-path mocks present — correct library behavior"
+
+  - name: orchestration_no_child_mocking
+    description: Library orchestration components should NOT mock children
+    if: "annotations.get('rule') == 'orchestration-exception'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      mock_pattern = re.compile(
+          r'(jest\.mock|vi\.mock|jest\.spyOn)\s*\([^)]*?(WizardNav|WizardStep|WizardFooter)'
+      )
+      if mock_pattern.search(text):
+          return False, "Orchestration children should not be mocked"
+      return True, "No orchestration mocking — correct exception behavior"
+
+thresholds:
+  has_test_content:
+    min_pass_rate: 1.0
+  consumer_no_child_mocking:
+    min_pass_rate: 1.0
+  library_mocks_children:
+    min_pass_rate: 1.0
+  orchestration_no_child_mocking:
+    min_pass_rate: 1.0


### PR DESCRIPTION
## Summary

First eval using agent-eval-harness. Tests the skill's unique value: detecting consumer vs library context and making the right mocking decisions.

- 3 test cases (consumer, library, library orchestration exception)
- 4 inline pass/fail checks, all passing at 100%

Run with: `/eval-run --config eval/pf-unit-test-generator/eval.yaml`

## Scoring results

```
has_test_content:               pass_rate=100.0%
consumer_no_child_mocking:      pass_rate=100.0%
library_mocks_children:         pass_rate=100.0%
orchestration_no_child_mocking: pass_rate=100.0%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new React components: ServiceCard, Tooltip, and Wizard, including their prop APIs and behaviors (status + last-updated display, tooltip show/hide on interaction, and multi-step navigation with save/back logic).
  * Added a dataset-driven unit-test generator evaluation job with automated judging checks.

* **Documentation**
  * Updated contribution guidance to require evals for consumer-facing skills and expanded local eval instructions.

* **Chores**
  * Updated evaluation configs and case fixtures/annotations, and ignored evaluation run output in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->