### PR TITLE
feat(PF-4272): add GitHub Actions skill eval CI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,6 +66,15 @@ reviews:
         files or resources outside the target project without explicit
         justification, and any network requests to URLs not provided by the
         user. Do not flag style or formatting.
+    - path: ".github/workflows/**"
+      instructions: >
+        GitHub Actions workflow files. Security checklist: actions must be
+        pinned to commit SHAs (not mutable tags like @v4), permissions must
+        be scoped to individual jobs (not workflow level), checkout steps
+        must set persist-credentials: false, secrets must not be exposed to
+        jobs that don't need them, and ${{ }} expressions must not appear
+        in run: blocks with user-controlled input (use env: instead). Flag
+        npm install or plugin install commands that use floating versions.
     - path: "scripts/**"
       instructions: >
         Repo-level automation scripts. Review for bugs, correctness, and

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,149 @@
+name: Skill Evals
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled]
+    paths:
+      - "plugins/*/skills/**"
+      - "eval/**"
+      - "!eval/runs/**"
+  workflow_dispatch:
+    inputs:
+      skill_name:
+        description: "Specific skill to evaluate (leave empty for auto-detect)"
+        required: false
+        type: string
+
+jobs:
+  detect-changes:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-evals')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      skills: ${{ steps.detect.outputs.skills }}
+      has_evals: ${{ steps.detect.outputs.has_evals }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed skills with evals
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SKILL_INPUT: ${{ inputs.skill_name }}
+        run: |
+          if [[ -n "$SKILL_INPUT" ]]; then
+            RESULT=$(bash scripts/detect-changed-skills.sh --skill "$SKILL_INPUT")
+          else
+            RESULT=$(bash scripts/detect-changed-skills.sh --base origin/main)
+          fi
+          while IFS='=' read -r key value; do
+            echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+          done <<< "$RESULT"
+          echo "$RESULT"
+
+  run-evals:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_evals == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        skill: ${{ fromJson(needs.detect-changes.outputs.skills) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code@2.1.190
+
+      - name: Install eval harness plugin
+        # Branch ref — plugin install does not support SHA pinning
+        run: claude plugin install agent-eval-harness@agent-eval-harness-dev
+
+      - name: Run eval for ${{ matrix.skill }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SKILL_NAME: ${{ matrix.skill }}
+        # dontAsk is safe — ephemeral CI runner, no persistent state
+        run: |
+          claude -p "/agent-eval-harness:eval-run --config eval/${SKILL_NAME}/eval.yaml --no-llm-judges" \
+            --allowedTools "Bash,Read,Write,Edit,Skill" \
+            --permission-mode dontAsk \
+            --max-turns 200
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: eval-${{ matrix.skill }}
+          path: |
+            eval/runs/*/*/summary.yaml
+            eval/runs/*/*/run_result.json
+          if-no-files-found: warn
+
+  post-results:
+    needs: [detect-changes, run-evals]
+    if: always() && needs.detect-changes.outputs.has_evals == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Download all eval artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: eval-artifacts
+          pattern: eval-*
+
+      - name: Install Python dependencies
+        run: pip install --quiet pyyaml
+
+      - name: Generate PR comment
+        run: |
+          mapfile -t DIRS < <(find eval-artifacts -name summary.yaml -exec dirname {} \;)
+          if [[ ${#DIRS[@]} -eq 0 ]]; then
+            echo "## Skill Eval Results" > /tmp/eval-comment.md
+            echo "" >> /tmp/eval-comment.md
+            echo "No eval results found. Check the workflow logs for errors." >> /tmp/eval-comment.md
+          else
+            bash scripts/parse-eval-results.sh "${DIRS[@]}" > /tmp/eval-comment.md
+          fi
+
+      - name: Post or update PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          EXISTING=$(gh pr view "$PR_NUMBER" --comments --json comments \
+            --jq '.comments[] | select(.body | startswith("## Skill Eval Results")) | .url' \
+            | tail -1)
+          if [[ -n "$EXISTING" ]]; then
+            COMMENT_ID=$(echo "$EXISTING" | grep -oE '[0-9]+$')
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -F body=@/tmp/eval-comment.md
+          else
+            gh pr comment "$PR_NUMBER" --body-file /tmp/eval-comment.md
+          fi

--- a/scripts/detect-changed-skills.sh
+++ b/scripts/detect-changed-skills.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect which skills changed in a PR and have corresponding evals.
+# Outputs JSON array for GitHub Actions matrix and sets has_evals flag.
+#
+# Usage:
+#   In GitHub Actions:  scripts/detect-changed-skills.sh [--skill <name>]
+#   Locally:            scripts/detect-changed-skills.sh --base main
+
+SKILL_NAME=""
+BASE_BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skill) SKILL_NAME="$2"; shift 2 ;;
+    --base) BASE_BRANCH="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -n "$SKILL_NAME" ]]; then
+  if [[ -f "eval/${SKILL_NAME}/eval.yaml" ]]; then
+    echo "skills=[\"${SKILL_NAME}\"]"
+    echo "has_evals=true"
+  else
+    echo "No eval found for skill: ${SKILL_NAME}" >&2
+    echo "skills=[]"
+    echo "has_evals=false"
+  fi
+  exit 0
+fi
+
+if [[ -n "${GITHUB_EVENT_NAME:-}" && "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+  CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || git diff --name-only "origin/${BASE_BRANCH:-main}...HEAD")
+elif [[ -n "$BASE_BRANCH" ]]; then
+  CHANGED_FILES=$(git diff --name-only "${BASE_BRANCH}...HEAD")
+else
+  CHANGED_FILES=$(git diff --name-only "origin/main...HEAD")
+fi
+
+if ((BASH_VERSINFO[0] < 4)); then
+  echo "Error: bash 4+ required (declare -A). macOS ships bash 3 — use 'brew install bash'." >&2
+  exit 1
+fi
+
+declare -A SKILLS_SEEN
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  if [[ "$file" =~ ^plugins/[^/]+/skills/([^/]+)/ ]]; then
+    SKILLS_SEEN["${BASH_REMATCH[1]}"]=1
+  fi
+
+  if [[ "$file" =~ ^eval/([^/]+)/ && ! "$file" =~ ^eval/runs/ ]]; then
+    SKILLS_SEEN["${BASH_REMATCH[1]}"]=1
+  fi
+done <<< "$CHANGED_FILES"
+
+EVAL_SKILLS=()
+for skill in "${!SKILLS_SEEN[@]}"; do
+  if [[ -f "eval/${skill}/eval.yaml" ]]; then
+    EVAL_SKILLS+=("\"${skill}\"")
+  fi
+done
+
+if [[ ${#EVAL_SKILLS[@]} -eq 0 ]]; then
+  echo "skills=[]"
+  echo "has_evals=false"
+else
+  IFS=','
+  echo "skills=[${EVAL_SKILLS[*]}]"
+  unset IFS
+  echo "has_evals=true"
+fi

--- a/scripts/parse-eval-results.sh
+++ b/scripts/parse-eval-results.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Parse eval summary.yaml and run_result.json into a markdown PR comment.
+#
+# Usage: scripts/parse-eval-results.sh <artifacts-dir> [<artifacts-dir> ...]
+# Each artifacts-dir should contain summary.yaml and run_result.json for one skill eval.
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <artifacts-dir> [<artifacts-dir> ...]" >&2
+  exit 1
+fi
+
+echo "## Skill Eval Results"
+echo ""
+
+OVERALL_PASS=true
+
+for DIR in "$@"; do
+  SUMMARY="${DIR}/summary.yaml"
+  RUN_RESULT="${DIR}/run_result.json"
+
+  if [[ ! -f "$SUMMARY" ]]; then
+    echo "**$(basename "$DIR")**: No summary.yaml found"
+    echo ""
+    OVERALL_PASS=false
+    continue
+  fi
+
+  # Derive skill name from artifact directory (eval-artifacts/eval-<skill>/...)
+  EVAL_CONFIG=""
+  IFS='/' read -ra PARTS <<< "$DIR"
+  for part in "${PARTS[@]}"; do
+    if [[ "$part" == eval-* && -f "eval/${part#eval-}/eval.yaml" ]]; then
+      EVAL_CONFIG="eval/${part#eval-}/eval.yaml"
+      break
+    fi
+  done
+
+  COST="n/a"
+  DURATION="n/a"
+  NUM_CASES="n/a"
+  if [[ -f "$RUN_RESULT" ]]; then
+    IFS='|' read -r COST DURATION NUM_CASES <<< "$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+s = int(d.get('duration_s', 0))
+print(f\"{d.get('cost_usd', 0):.2f}|{s // 60}m {s % 60}s|{d.get('num_cases', 'n/a')}\")
+" "$RUN_RESULT")"
+  fi
+
+  echo "### $(basename "$DIR")"
+  echo ""
+  echo "| Judge | Pass Rate | Threshold | Status |"
+  echo "|-------|-----------|-----------|--------|"
+
+  SKILL_PASS=true
+  JUDGE_OUTPUT=$(python3 -c "
+import yaml, sys, os
+
+thresholds = {}
+config_path = sys.argv[2] if len(sys.argv) > 2 else ''
+if config_path and os.path.exists(config_path):
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    thresholds = config.get('thresholds', {})
+
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+judges = data.get('judges', {})
+for name, info in sorted(judges.items()):
+    rate = info.get('pass_rate', 0)
+    pct = f'{rate * 100:.0f}%'
+    min_rate = thresholds.get(name, {}).get('min_pass_rate', 1.0)
+    min_pct = f'{min_rate * 100:.0f}%'
+    status = 'PASS' if rate >= min_rate else 'FAIL'
+    print(f'| {name} | {pct} | {min_pct} | {status} |')
+    if rate < min_rate:
+        print('FAIL_FLAG')
+" "$SUMMARY" "$EVAL_CONFIG" 2>/dev/null) || true
+
+  echo "$JUDGE_OUTPUT" | grep -v '^FAIL_FLAG$'
+
+  if echo "$JUDGE_OUTPUT" | grep -q '^FAIL_FLAG$'; then
+    SKILL_PASS=false
+    OVERALL_PASS=false
+  fi
+
+  echo ""
+  echo "**Cost**: \$${COST} | **Duration**: ${DURATION} | **Cases**: ${NUM_CASES}"
+  echo ""
+
+  python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+per_case = data.get('per_case', {})
+judges = sorted(data.get('judges', {}).keys())
+
+print('<details>')
+print('<summary>Per-case details</summary>')
+print()
+header = '| Case | ' + ' | '.join(judges) + ' |'
+sep = '|------|' + '|'.join(['------' for _ in judges]) + '|'
+print(header)
+print(sep)
+
+for case_name in sorted(per_case.keys()):
+    case_data = per_case[case_name]
+    cols = [case_name]
+    for j in judges:
+        result = case_data.get(j, {})
+        val = result.get('value')
+        if val is None:
+            cols.append('skip')
+        elif val:
+            cols.append('PASS')
+        else:
+            cols.append('FAIL')
+    print('| ' + ' | '.join(cols) + ' |')
+
+print()
+print('</details>')
+" "$SUMMARY"
+
+  echo ""
+
+  if [[ "$SKILL_PASS" == "true" ]]; then
+    echo "Result: **PASS**"
+  else
+    echo "Result: **FAIL**"
+  fi
+  echo ""
+  echo "---"
+  echo ""
+done
+
+if [[ "$OVERALL_PASS" == "true" ]]; then
+  echo "Overall: **PASS**"
+else
+  echo "Overall: **FAIL**"
+fi


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically runs skill evals when skill or eval files change in a PR
- Detects which changed skills have corresponding evals and fans out via matrix strategy
- Parses eval results and posts a summary comment on the PR
- Narrows `.gitignore` from `eval/` to `eval/runs/` so new eval configs can be tracked without `git add -f`

## Setup required

- Add `ANTHROPIC_API_KEY` as a GitHub repo secret
- After merge, trigger via `workflow_dispatch` to validate end-to-end (this PR's paths won't trigger the workflow itself)

## How it works

1. **detect-changes** — identifies which changed skills have an `eval/<skill>/eval.yaml`
2. **run-evals** — installs Claude Code + eval harness plugin, runs each eval headlessly via matrix
3. **post-results** — downloads artifacts, generates a markdown summary table, posts/updates a PR comment

Closes: [PF-4272](https://redhat.atlassian.net/browse/PF-4272)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated skill evaluation runs for relevant pull request changes, with optional manual runs for a specific skill.
  * Evaluation results are now collected and posted back to the pull request as an updated summary comment.
  * Added clearer reporting for evaluation outcomes, including pass/fail status, timing, cost, and case-level details.

* **Chores**
  * Improved workflow review guidance for safer automation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->