### PR TITLE
feat(PF-4357): add plugin-workflows for aap-sdlc-harness integration

### DIFF
--- a/plugin-workflows/aap-sdlc-harness/patternfly.md
+++ b/plugin-workflows/aap-sdlc-harness/patternfly.md
@@ -1,0 +1,17 @@
+## PatternFly Workflow Integration
+
+When `package.json` contains `@patternfly/*` dependencies and PatternFly
+plugin skills are available, invoke these as pre/post-steps.
+
+### After `/code-review`
+
+- `/pf-component-structure` — validate component nesting, wrapper hierarchies, layout composition
+- `/pf-import-checker` — verify import paths across `@patternfly/react-core`, `react-icons`, `react-table`
+- `/pf-raw-colors-scan` — find hardcoded hex/rgb/hsl values that should use PF design tokens
+- `/pf-token-auditor` — audit design token usage against PF6 token architecture
+
+### After `/story-implementation-workflow`
+
+- `/pf-unit-test-generator` — generate unit tests using Testing Library with PF-aware patterns
+- `/pf-component-structure` — validate component hierarchy before committing
+- `/pf-import-checker` — verify imports resolve correctly


### PR DESCRIPTION
## Summary
- Add `plugin-workflows/aap-sdlc-harness/patternfly.md` — maps PF skills to ATAT harness workflows (`/code-review`, `/story-implementation-workflow`)

## Context

Part of PF-4357. The harness team requested that PF-specific workflow integration content be maintained by the PF team in this repo, rather than living in the harness repo where changes would require their review cycle.

The generic infrastructure (CLAUDE.md pointer, README, TEMPLATE) stays in the harness repo. The PF-specific content lives here, organized by consumer harness subdirectory so different products (ATAT, Firefly, etc.) can each have their own integration without conflicts.

**Related MRs:**
- Harness MR !141: https://gitlab.cee.redhat.com/atat/harness/-/merge_requests/141 (generic infra — CLAUDE.md pointer, README, TEMPLATE)
- Carbonite MR !176: https://gitlab.cee.redhat.com/atat/carbonite/-/merge_requests/176 (copy mechanism)

Closes: PF-4357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for PatternFly-related workflows.
  * Clarified when PatternFly checks should run and what validations are performed after review and story implementation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->