### PR TITLE
feat(PF-4363): add pf-assist agent and eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ prototypes/
 tmp/
 
 # Eval run artifacts
-eval/
+eval/runs/
 
 # Local Claude Code settings (user-specific)
 .claude/settings.local.json

--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -69,7 +69,7 @@ Every skill or agent must live in a plugin. Pick the one that matches your skill
 | **design-guide** | Choose the right PF components and patterns when building | Does this help me choose the right PF components and patterns when building? | `pf-ai-experience-patterns`, `pf-design-mode` |
 | **migration** | Upgrade PatternFly versions | Does this help me upgrade PF versions? | `pf-class-migration-scanner` |
 | **pf-workshop** | Team tools and skill incubation | Is this a team workflow tool, or a new skill that isn't ready for a consumer plugin yet? | `analytics-repo-pruning`, `css-var-analyzer`, `duplicate-epic` |
-| **react** | Develop and test React components | Does this help me write or test a React component? | `pf-component-structure`, `pf-import-checker`, `pf-project-scaffolder` |
+| **react** | Develop and test React components | Does this help me write or test a React component? | `pf-component-structure`, `pf-design-comments`, `pf-import-checker` |
 <!-- END PLUGIN TABLE -->
 
 **How to decide:**

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -27,7 +27,9 @@ No skills or agents yet.
 
 Code review and quality — adversarial review, security patterns
 
-No skills or agents yet.
+| Agent | Description |
+|-------|-------------|
+| `pf-assist` | PatternFly development routing — maps code changes, test gaps, scaffolding needs, and design work to the right PF sub-skills. |
 
 
 <br>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/patternfly/ai-helpers)](./LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Plugins](https://img.shields.io/badge/plugins-7-blueviolet)](./PLUGINS.md)
-[![Skills](https://img.shields.io/badge/skills-27-blue)](./PLUGINS.md)
+[![Skills](https://img.shields.io/badge/skills-28-blue)](./PLUGINS.md)
 
 AI coding helpers for [PatternFly](https://www.patternfly.org/) development. This repository provides plugins and documentation to help AI tools generate accurate, best-practice PatternFly applications.
 

--- a/eval/pf-assist/cases/non-pf-gate-check/annotations.yaml
+++ b/eval/pf-assist/cases/non-pf-gate-check/annotations.yaml
@@ -1,0 +1,1 @@
+expected_routing: none

--- a/eval/pf-assist/cases/non-pf-gate-check/input.yaml
+++ b/eval/pf-assist/cases/non-pf-gate-check/input.yaml
@@ -1,0 +1,1 @@
+prompt: "I just finished a code review of this project covering functionality, security, and quality. Are there any framework-specific checks I should also run? Look at the actual source files."

--- a/eval/pf-assist/cases/non-pf-gate-check/package.json
+++ b/eval/pf-assist/cases/non-pf-gate-check/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vanilla-react-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "vitest": "^1.3.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/eval/pf-assist/cases/non-pf-gate-check/src/components/UserCard.tsx
+++ b/eval/pf-assist/cases/non-pf-gate-check/src/components/UserCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface UserCardProps {
+  name: string;
+  email: string;
+  avatar: string;
+}
+
+const UserCard: React.FC<UserCardProps> = ({ name, email, avatar }) => {
+  return (
+    <div className="user-card">
+      <img src={avatar} alt={name} />
+      <h3>{name}</h3>
+      <p>{email}</p>
+    </div>
+  );
+};
+
+export default UserCard;

--- a/eval/pf-assist/cases/pf-testing-gap/annotations.yaml
+++ b/eval/pf-assist/cases/pf-testing-gap/annotations.yaml
@@ -1,0 +1,2 @@
+expected_routing:
+  - pf-unit-test-generator

--- a/eval/pf-assist/cases/pf-testing-gap/input.yaml
+++ b/eval/pf-assist/cases/pf-testing-gap/input.yaml
@@ -1,0 +1,1 @@
+prompt: "I just implemented this AlertBanner component. There are no test files yet. What should I do next?"

--- a/eval/pf-assist/cases/pf-testing-gap/package.json
+++ b/eval/pf-assist/cases/pf-testing-gap/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pf-eval-testing",
+  "version": "1.0.0",
+  "dependencies": {
+    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-icons": "^6.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "vitest": "^1.3.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/eval/pf-assist/cases/pf-testing-gap/src/components/AlertBanner.tsx
+++ b/eval/pf-assist/cases/pf-testing-gap/src/components/AlertBanner.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Alert, AlertGroup, AlertActionCloseButton } from '@patternfly/react-core';
+
+interface AlertItem {
+  id: string;
+  title: string;
+  variant: 'success' | 'danger' | 'warning' | 'info';
+}
+
+interface AlertBannerProps {
+  alerts: AlertItem[];
+  onDismiss: (id: string) => void;
+}
+
+const AlertBanner: React.FC<AlertBannerProps> = ({ alerts, onDismiss }) => {
+  return (
+    <AlertGroup isToast isLiveRegion>
+      {alerts.map((alert) => (
+        <Alert
+          key={alert.id}
+          variant={alert.variant}
+          title={alert.title}
+          actionClose={<AlertActionCloseButton onClose={() => onDismiss(alert.id)} />}
+        />
+      ))}
+    </AlertGroup>
+  );
+};
+
+export default AlertBanner;

--- a/eval/pf-assist/cases/pf-validation-routing/annotations.yaml
+++ b/eval/pf-assist/cases/pf-validation-routing/annotations.yaml
@@ -1,0 +1,5 @@
+expected_routing:
+  - pf-raw-colors-scan
+  - pf-compliance-checker
+  - pf-import-checker
+  - pf-token-auditor

--- a/eval/pf-assist/cases/pf-validation-routing/input.yaml
+++ b/eval/pf-assist/cases/pf-validation-routing/input.yaml
@@ -1,0 +1,1 @@
+prompt: "I just finished a code review of this project covering functionality, security, and quality. Are there any framework-specific checks I should also run? Look at the actual source files."

--- a/eval/pf-assist/cases/pf-validation-routing/package.json
+++ b/eval/pf-assist/cases/pf-validation-routing/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pf-eval-validation",
+  "version": "1.0.0",
+  "dependencies": {
+    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-icons": "^6.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/eval/pf-assist/cases/pf-validation-routing/src/components/StatusCard.tsx
+++ b/eval/pf-assist/cases/pf-validation-routing/src/components/StatusCard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+
+interface StatusCardProps {
+  title: string;
+  healthy: boolean;
+}
+
+const StatusCard: React.FC<StatusCardProps> = ({ title, healthy }) => {
+  return (
+    <Card style={{ backgroundColor: healthy ? '#3E8635' : '#C9190B' }}>
+      <CardTitle>{title}</CardTitle>
+      <CardBody>
+        <span style={{ color: '#FFFFFF', fontSize: '14px' }}>
+          {healthy ? 'Healthy' : 'Down'}
+        </span>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default StatusCard;

--- a/eval/pf-assist/eval.yaml
+++ b/eval/pf-assist/eval.yaml
@@ -1,0 +1,108 @@
+name: pf-assist-eval
+description: Evaluate pf-assist agent's routing influence — does it surface specific PF sub-skills contextually?
+
+skill: ""
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+  plugin_dirs:
+    - ./plugins/code-review
+
+models:
+  skill: claude-sonnet-4-6
+  judge: claude-sonnet-4-6
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory IS the workspace (cwd for claude --print).
+    Fixture files (package.json, .tsx components) go directly in the case dir.
+    - input.yaml: prompt field with a realistic post-workflow question
+    - annotations.yaml: expected_routing (list of sub-skill names) or gate-skip
+    Only the code-review plugin is loaded (plugin_dirs above). The agent routes
+    to skills across multiple plugins (react, design-audit, etc.), but judges
+    test routing influence (does the agent mention skill names), not execution.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: routes_to_subskills
+    description: Output references specific /pf-* sub-skill names from the agent's routing table
+    if: "annotations.get('expected_routing', []) and annotations.get('expected_routing') != 'none'"
+    check: |
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      text_lower = text.lower()
+      expected = annotations.get("expected_routing", [])
+      found = []
+      missing = []
+      for skill_name in expected:
+          normalized = skill_name.lower().replace("/", "")
+          if normalized in text_lower or skill_name.lower() in text_lower:
+              found.append(skill_name)
+          else:
+              missing.append(skill_name)
+      if not found:
+          return False, f"No expected sub-skills referenced. Expected: {expected}"
+      if missing:
+          return True, f"Found {found}, missing {missing} (partial match acceptable)"
+      return True, f"All expected sub-skills referenced: {found}"
+
+  - name: gate_skip_non_pf
+    description: Non-PF project gets no PF-specific routing — generic advice only
+    if: "annotations.get('expected_routing') == 'none'"
+    check: |
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      text_lower = text.lower()
+      pf_subskills = [
+          "pf-compliance-checker", "pf-raw-colors-scan", "pf-import-checker",
+          "pf-component-structure", "pf-unit-test-generator", "pf-token-auditor",
+          "pf-class-migration-scanner", "pf-project-scaffolder", "pf-figma-icon-finder",
+          "pf-design-mode", "pf-design-comments", "pf-ai-experience-patterns"
+      ]
+      found_pf = [s for s in pf_subskills if s in text_lower]
+      if found_pf:
+          return False, f"Non-PF project got PF-specific routing: {found_pf}"
+      return True, "No PF sub-skill routing for non-PF project — gate check working"
+
+  - name: actionable_next_step
+    description: Output includes a concrete next action (run a skill, apply a fix), not just a description
+    if: "annotations.get('expected_routing', []) and annotations.get('expected_routing') != 'none'"
+    check: |
+      text = outputs.get("conversation", "")
+      for path, content in outputs.get("files", {}).items():
+          text += "\n" + content
+      text_lower = text.lower()
+      action_signals = [
+          "run ", "want me to", "should i", "let me run",
+          "i can run", "try running", "execute", "invoke",
+          "recommended", "start with", "first,", "next step"
+      ]
+      has_action = any(s in text_lower for s in action_signals)
+      if not has_action:
+          return False, "Output describes issues but doesn't offer actionable next steps"
+      return True, "Output includes actionable next steps"
+
+thresholds:
+  routes_to_subskills:
+    min_pass_rate: 1.0
+  gate_skip_non_pf:
+    min_pass_rate: 1.0
+  actionable_next_step:
+    min_pass_rate: 0.67

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -12,5 +12,6 @@
     "url": "https://www.patternfly.org"
   },
   "repository": "https://github.com/patternfly/ai-helpers",
-  "license": "MIT"
+  "license": "MIT",
+  "agents": ["./agents/"]
 }

--- a/plugins/code-review/.cursor-plugin/plugin.json
+++ b/plugins/code-review/.cursor-plugin/plugin.json
@@ -12,5 +12,6 @@
     "url": "https://www.patternfly.org"
   },
   "repository": "https://github.com/patternfly/ai-helpers",
-  "license": "MIT"
+  "license": "MIT",
+  "agents": ["./agents/"]
 }

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -4,7 +4,11 @@
 
 Code review and quality — adversarial review, security patterns.
 
-No skills or agents yet.
+## What's Included
+
+### Agents
+
+- **PF Assist** (`pf-assist`) — PatternFly development routing — maps code changes, test gaps, scaffolding needs, and design work to the right PF sub-skills.
 
 ## Sources
 

--- a/plugins/code-review/agents/pf-assist.md
+++ b/plugins/code-review/agents/pf-assist.md
@@ -1,0 +1,55 @@
+---
+name: pf-assist
+description: PatternFly development routing — maps code changes, test gaps, scaffolding needs, and design work to the right PF sub-skills. Active when working in any project with @patternfly/* dependencies.
+---
+
+# PatternFly assist
+
+Route to the right PatternFly consumer skills based on what the developer is doing. Skip entirely if the project does not depend on `@patternfly/*` packages.
+
+## Sub-skills by context
+
+Identify the current context from the developer's recent activity, then apply the relevant sub-skills. Multiple contexts can apply simultaneously.
+
+### Validation — code has been written or modified
+
+| Sub-skill | What it checks | Plugin |
+|-----------|---------------|--------|
+| `/pf-component-structure` | Component nesting, wrapper hierarchies, layout composition | react |
+| `/pf-import-checker` | Import paths across `@patternfly/*` packages | react |
+| `/pf-raw-colors-scan` | Hardcoded hex/rgb/hsl values that should use design tokens | design-audit |
+| `/pf-token-auditor` | Design token usage against PF token architecture | design-audit |
+| `/pf-compliance-checker` | Component usage against PF design guidelines | design-audit |
+| `/pf-class-migration-scanner` | Legacy CSS classes from older PF versions | migration |
+
+### Testing — implementation done or tests needed
+
+| Sub-skill | What it does | Plugin |
+|-----------|-------------|--------|
+| `/pf-unit-test-generator` | Generate unit tests for React components using Testing Library | react |
+
+### Scaffolding — starting a new project or feature
+
+| Sub-skill | What it does | Plugin |
+|-----------|-------------|--------|
+| `/pf-project-scaffolder` | Scaffold a PF React project with PF6-safe dependencies and starter layout | react |
+
+### Design — Figma or design-related work
+
+| Sub-skill | What it does | Plugin |
+|-----------|-------------|--------|
+| `/pf-figma-icon-finder` | Identify PF icons in Figma mockups and provide React imports | design-audit |
+| `/pf-design-mode` | Create and edit Figma files using PF component libraries | design-guide |
+| `/pf-design-comments` | Integrate `@patternfly/design-comments` for on-page design feedback | react |
+| `/pf-ai-experience-patterns` | Apply Red Hat's AI design language to AI-powered features | design-guide |
+
+## Context detection
+
+Determine which contexts apply based on observable signals:
+
+- **Validation**: changed or new `.tsx`, `.jsx`, `.css`, `.scss` files that import from `@patternfly/*`
+- **Testing**: recently implemented or modified components without corresponding test updates
+- **Scaffolding**: empty or new project directory, `package.json` just created, user asked to scaffold
+- **Design**: Figma URLs in conversation, design-related user requests, `.figma` references
+
+When multiple contexts apply, run all relevant sub-skills and group findings by context. Only include context sections that were activated. Attribute findings to the specific sub-skill that produced them.

--- a/plugins/react/.claude-plugin/plugin.json
+++ b/plugins/react/.claude-plugin/plugin.json
@@ -14,5 +14,6 @@
     "url": "https://www.patternfly.org"
   },
   "repository": "https://github.com/patternfly/ai-helpers",
-  "license": "MIT"
+  "license": "MIT",
+  "agents": ["./agents/"]
 }

--- a/plugins/react/.cursor-plugin/plugin.json
+++ b/plugins/react/.cursor-plugin/plugin.json
@@ -14,5 +14,6 @@
     "url": "https://www.patternfly.org"
   },
   "repository": "https://github.com/patternfly/ai-helpers",
-  "license": "MIT"
+  "license": "MIT",
+  "agents": ["./agents/"]
 }

--- a/plugins/react/README.md
+++ b/plugins/react/README.md
@@ -9,44 +9,17 @@ React component development — coding standards, testing, and structure.
 ### Skills
 
 - **PF Component Structure** (`/react:pf-component-structure`) — Audit PatternFly React component nesting, wrapper hierarchies, and layout structure.
+- **PF Design Comments** (`/react:pf-design-comments`) — Integrate @patternfly/design-comments into React apps for on-page design feedback, pinned comment threads, GitHub Issues sync, and Jira linking.
 - **PF Import Checker** (`/react:pf-import-checker`) — Audit and fix invalid PatternFly import paths across packages.
 - **PF Project Scaffolder** (`/react:pf-project-scaffolder`) — Scaffolds PatternFly React projects with PF6-safe dependencies, imports, and starter layout.
 - **PF Unit Test Generator** (`/react:pf-unit-test-generator`) — Generate a unit test file for a React component using Testing Library.
 
-**PF Unit Test Generator** (`/react:pf-unit-test-generator`) — Generates a complete unit test file for a given React component. Works for both consumer applications and component library contributions, following Testing Library best practices.
-**PF Component Structure** (`/react:pf-component-structure`) — Audit PatternFly React component nesting, wrapper hierarchies, and layout structure.
-
-**PF Import Checker** (`/react:pf-import-checker`) — Audit and fix invalid PatternFly import paths across packages.
-
-**PF Project Scaffolder** (`/react:pf-project-scaffolder`) — Scaffolds PatternFly React projects with PF6-safe dependencies, imports, and starter layout.
-
-**PF Design Comments** (`/react:pf-design-comments`) — Integrates `@patternfly/design-comments` for on-page design feedback with optional GitHub and Jira sync.
 ### Agents
 
 - **PF Coding Standards** (`pf-coding-standards`) — PatternFly React coding standards — import patterns, component composition, token usage, and style conventions.
 - **PF Component Structure Audit** (`pf-component-structure-audit`) — PatternFly React structural composition rules — required hierarchies, wrapper components, and props-vs-children patterns.
 - **PF Unit Test Standards** (`pf-unit-test-standards`) — PatternFly React unit testing standards — RTL patterns, mock boundaries, coverage expectations, and assertion style.
 
-## File Structure
-```text
-react/
-├── .claude-plugin/
-│   └── plugin.json
-├── .cursor-plugin/
-│   └── plugin.json
-├── agents/
-│   ├── component-structure-audit.md
-│   ├── pf-coding-standards.md
-│   └── pf-unit-test-standards.md
-├── skills/
-│   ├── pf-component-structure/
-│   ├── pf-import-checker/
-│   ├── pf-project-scaffolder/
-│   ├── pf-design-comments/
-│   ├── pf-prototype-mode/
-│   └── pf-unit-test-generator/
-└── README.md
-```
 ## Sources
 
 - [PatternFly.org](https://www.patternfly.org/)


### PR DESCRIPTION
## Summary

- Adds `pf-assist` as an agent in the `code-review` plugin — always-on routing knowledge that makes every PF consumer skill contextually available to any `@patternfly/*` project
- Gate checks for `@patternfly/*` in `package.json` and exits immediately on non-PF projects
- Contextually routes to the right PF skills based on what the developer is doing (validation, testing, scaffolding, design)
- Adds agent eval using `skill: ""` + `plugin_dirs` — tests behavioral influence (does the agent surface specific sub-skill names?) with 3 test cases and 3 judges
- Declares `agents` field in plugin.json for both `react` and `code-review` plugins — required for marketplace installs to discover agents (auto-discovery only works with direct `--plugin-dir` installs)
- Regenerates PLUGINS.md and plugin READMEs (also fixes duplicate entries in react README)

### Skills routed contextually

| Context | Skills invoked |
|---------|---------------|
| Code changes (validation) | `/pf-component-structure`, `/pf-import-checker`, `/pf-raw-colors-scan`, `/pf-token-auditor`, `/pf-compliance-checker`, `/pf-class-migration-scanner` |
| After implementation (testing) | `/pf-unit-test-generator` |
| New projects (scaffolding) | `/pf-project-scaffolder` |
| Figma/design work | `/pf-figma-icon-finder`, `/pf-design-mode`, `/pf-design-comments`, `/pf-ai-experience-patterns` |

### Eval coverage

| Test case | What it tests | Judge |
|-----------|--------------|-------|
| `pf-validation-routing` | PF project with hardcoded hex colors routes to validation sub-skills | `routes_to_subskills` |
| `non-pf-gate-check` | Non-PF project gets no PF-specific routing | `gate_skip_non_pf` |
| `pf-testing-gap` | PF component without tests routes to unit test generator | `routes_to_subskills` |

Closes: PF-4363