### PR TITLE
feat(PF-4339,PF-4346,PF-4343): add scanner skill evals

### DIFF
--- a/CONTRIBUTING-SKILLS.md
+++ b/CONTRIBUTING-SKILLS.md
@@ -67,7 +67,7 @@ Every skill or agent must live in a plugin. Pick the one that matches your skill
 | **code-review** | Review code for quality | Does this help me review code for quality? |  |
 | **design-audit** | Validate existing code/designs against PF standards | Does this check whether existing code or designs follow PF standards? | `pf-compliance-checker`, `pf-design-token-check`, `pf-figma-icon-finder` |
 | **design-guide** | Choose the right PF components and patterns when building | Does this help me choose the right PF components and patterns when building? | `pf-ai-experience-patterns`, `pf-design-mode` |
-| **migration** | Upgrade PatternFly versions | Does this help me upgrade PF versions? | `pf-class-migration-scanner` |
+| **migration** | Upgrade PatternFly versions | Does this help me upgrade PF versions? | `pf-class-migration-scanner`, `pf-react-breaking-changes` |
 | **patternfly-mcp** | Connect AI tools to PatternFly documentation and component data |  |  |
 | **pf-workshop** | Team tools and skill incubation | Is this a team workflow tool, or a new skill that isn't ready for a consumer plugin yet? | `analytics-repo-pruning`, `css-var-analyzer`, `duplicate-epic` |
 | **react** | Develop and test React components | Does this help me write or test a React component? | `pf-component-structure`, `pf-design-comments`, `pf-github-pages-deploy` |

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -100,7 +100,7 @@ PatternFly team tools and skill incubation — issue triage, release management,
 | `icon-finder` | Find Red Hat Design System icons (@rhds/icons) by keyword or use case with visual previews. |
 | `pf-analyze-modifiers` | Analyze PatternFly modifier class (pf-m-*) usage across SCSS files and generate usage reports. |
 | `pf-bug-triage` | Triage PatternFly bug reports — assess completeness, suggest fixes, identify affected components, and recommend assignees. |
-| `pf-content-review` | Audit and rewrite content to match PatternFly and Red Hat voice and tone standards. |
+| `pf-content-review` | Review content against PatternFly and Red Hat voice and tone standards. |
 | `pf-create-issue` | Create well-structured GitHub issues for PatternFly repositories with templates, follow-up tracking, and duplicate detection. |
 | `pf-org-version-update` | Update patternfly-org for a new PatternFly release — resolve versions, update package.json and versions.json, and provide build steps. |
 | `pf-tokens` | Build CSS design tokens for PatternFly core and copy them to the PatternFly repository. |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/patternfly/ai-helpers)](./LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Plugins](https://img.shields.io/badge/plugins-8-blueviolet)](./PLUGINS.md)
-[![Skills](https://img.shields.io/badge/skills-31-blue)](./PLUGINS.md)
+[![Skills](https://img.shields.io/badge/skills-32-blue)](./PLUGINS.md)
 
 AI coding helpers for [PatternFly](https://www.patternfly.org/) development. This repository provides plugins and documentation to help AI tools generate accurate, best-practice PatternFly applications.
 

--- a/eval/pf-class-migration-scanner/cases/legacy-token-patterns/_legacy-overrides.scss
+++ b/eval/pf-class-migration-scanner/cases/legacy-token-patterns/_legacy-overrides.scss
@@ -1,0 +1,16 @@
+.app-sidebar {
+  background-color: var(--pf-global--BackgroundColor--dark-300);
+  color: var(--pf-global--Color--light-100);
+  border-right: 1px solid var(--pf-global--BorderColor--100);
+}
+
+.app-header {
+  font-size: var(--pf-v6--global--FontSize--xl);
+  color: var(--pf-v6--global--Color--brand--default);
+  padding: var(--pf-v6--global--spacer--md);
+}
+
+.app-alert {
+  background-color: var(--pf-global--danger-color--100);
+  color: var(--pf-global--Color--light-100);
+}

--- a/eval/pf-class-migration-scanner/cases/legacy-token-patterns/annotations.yaml
+++ b/eval/pf-class-migration-scanner/cases/legacy-token-patterns/annotations.yaml
@@ -1,0 +1,5 @@
+expect_violations: true
+violation_type: legacy-tokens
+legacy_patterns:
+  - "--pf-global--"
+  - "--pf-v6--"

--- a/eval/pf-class-migration-scanner/cases/legacy-token-patterns/input.yaml
+++ b/eval/pf-class-migration-scanner/cases/legacy-token-patterns/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Check this SCSS file for deprecated PatternFly token patterns that need to migrate to semantic tokens."
+fixture: _legacy-overrides.scss

--- a/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/LegacyNavbar.tsx
+++ b/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/LegacyNavbar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface NavbarProps {
+  items: { label: string; href: string; isActive?: boolean }[];
+  onLogout: () => void;
+}
+
+export const LegacyNavbar: React.FC<NavbarProps> = ({ items, onLogout }) => (
+  <div className="pf-c-page">
+    <nav className="pf-v5-c-nav" aria-label="Main navigation">
+      <ul className="pf-v5-c-nav__list">
+        {items.map((item) => (
+          <li
+            key={item.href}
+            className={`pf-v5-c-nav__item ${item.isActive ? 'pf-v5-c-nav__item--current' : ''}`}
+          >
+            <a href={item.href} className="pf-v5-c-nav__link">
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+    <div className="pf-u-mt-md pf-u-text-align-right">
+      <button
+        className="pf-v5-c-button pf-m-secondary"
+        onClick={onLogout}
+        type="button"
+      >
+        Log out
+      </button>
+    </div>
+  </div>
+);

--- a/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/annotations.yaml
+++ b/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/annotations.yaml
@@ -1,0 +1,7 @@
+expect_violations: true
+violation_type: legacy-classes
+legacy_patterns:
+  - "pf-v5-c-button"
+  - "pf-v5-c-nav"
+  - "pf-c-page"
+  - "pf-u-mt-md"

--- a/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/input.yaml
+++ b/eval/pf-class-migration-scanner/cases/legacy-versioned-classes/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Scan this React component for legacy PatternFly CSS classes that need to be migrated to PF6."
+fixture: LegacyNavbar.tsx

--- a/eval/pf-class-migration-scanner/cases/valid-pf6-code/ModernCard.tsx
+++ b/eval/pf-class-migration-scanner/cases/valid-pf6-code/ModernCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  CardFooter,
+  Button,
+  Label,
+} from '@patternfly/react-core';
+
+interface ModernCardProps {
+  title: string;
+  description: string;
+  status: 'active' | 'inactive';
+  onAction: () => void;
+}
+
+export const ModernCard: React.FC<ModernCardProps> = ({
+  title,
+  description,
+  status,
+  onAction,
+}) => (
+  <Card>
+    <CardTitle>
+      {title}
+      <Label
+        color={status === 'active' ? 'green' : 'grey'}
+        className="pf-v6-u-ml-sm"
+      >
+        {status}
+      </Label>
+    </CardTitle>
+    <CardBody>{description}</CardBody>
+    <CardFooter>
+      <Button variant="primary" onClick={onAction}>
+        View Details
+      </Button>
+    </CardFooter>
+  </Card>
+);

--- a/eval/pf-class-migration-scanner/cases/valid-pf6-code/annotations.yaml
+++ b/eval/pf-class-migration-scanner/cases/valid-pf6-code/annotations.yaml
@@ -1,0 +1,1 @@
+expect_violations: false

--- a/eval/pf-class-migration-scanner/cases/valid-pf6-code/input.yaml
+++ b/eval/pf-class-migration-scanner/cases/valid-pf6-code/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Scan this component for any legacy PatternFly classes or deprecated token usage."
+fixture: ModernCard.tsx

--- a/eval/pf-class-migration-scanner/eval.yaml
+++ b/eval/pf-class-migration-scanner/eval.yaml
@@ -1,0 +1,129 @@
+name: pf-class-migration-scanner-eval
+description: Evaluate pf-class-migration-scanner's detection of legacy PF classes and token patterns
+
+skill: migration:pf-class-migration-scanner
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-6
+  judge: claude-sonnet-4-6
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: prompt field with a realistic user request
+    - annotations.yaml: expect_violations (true/false) and legacy_patterns for conditional judges
+    - A .tsx or .scss fixture file the prompt references
+
+outputs:
+  - path: artifacts
+    schema: |
+      The skill produces a text report listing legacy classes/tokens
+      with file path, current class, recommended replacement, and confidence.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: flags_legacy_classes
+    description: Detects legacy versioned and unversioned PF class prefixes
+    if: "annotations.get('expect_violations') == True and annotations.get('violation_type') == 'legacy-classes'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      patterns = annotations.get("legacy_patterns", [])
+      if not patterns:
+          return False, "Test case missing legacy_patterns annotation"
+      found = 0
+      for pattern in patterns:
+          if pattern in text:
+              found += 1
+      if found == 0:
+          return False, f"Did not flag any legacy classes: {patterns}"
+      if found < len(patterns):
+          return False, f"Only found {found}/{len(patterns)} legacy patterns"
+      return True, f"Correctly flagged all {len(patterns)} legacy class patterns"
+
+  - name: flags_legacy_tokens
+    description: Detects legacy token patterns that should use semantic tokens
+    if: "annotations.get('expect_violations') == True and annotations.get('violation_type') == 'legacy-tokens'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      patterns = annotations.get("legacy_patterns", [])
+      if not patterns:
+          return False, "Test case missing legacy_patterns annotation"
+      found = 0
+      for pattern in patterns:
+          if pattern in text:
+              found += 1
+      if found == 0:
+          return False, f"Did not flag any legacy tokens: {patterns}"
+      return True, f"Flagged {found}/{len(patterns)} legacy token patterns"
+
+  - name: suggests_pf6_replacement
+    description: Recommends PF6-appropriate replacements (pf-v6-u-* or --pf-t--*)
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      pf6_class = re.compile(r'pf-v6-')
+      pf6_token = re.compile(r'--pf-t--')
+      if not pf6_class.search(text) and not pf6_token.search(text):
+          return False, "No PF6 replacement suggestions (pf-v6-* or --pf-t--*) found"
+      return True, "Suggests PF6-appropriate replacements"
+
+  - name: includes_confidence
+    description: Output includes confidence levels for findings
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "").lower()
+      confidence = re.compile(r'\b(high|medium|low)\b.*confidence|\bconfidence\b.*\b(high|medium|low)\b')
+      if not confidence.search(text):
+          return False, "Missing confidence levels in findings"
+      return True, "Includes confidence levels"
+
+  - name: no_false_positives
+    description: Does not flag valid PF6 code as legacy
+    if: "annotations.get('expect_violations') == False"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      pf6_classes = ["pf-v6-u-ml-sm"]
+      for cls in pf6_classes:
+          pattern = re.compile(
+              r'(legacy|deprecated|migrate|violation|replace|remove).*'
+              + re.escape(cls),
+              re.IGNORECASE
+          )
+          if pattern.search(text):
+              return False, f"False positive — flagged valid PF6 class as legacy: {cls}"
+      return True, "No false positives for valid PF6 code"
+
+thresholds:
+  flags_legacy_classes:
+    min_pass_rate: 1.0
+  flags_legacy_tokens:
+    min_pass_rate: 1.0
+  suggests_pf6_replacement:
+    min_pass_rate: 1.0
+  includes_confidence:
+    min_pass_rate: 1.0
+  no_false_positives:
+    min_pass_rate: 1.0

--- a/eval/pf-import-checker/cases/invalid-charts-import/ChartsDashboard.tsx
+++ b/eval/pf-import-checker/cases/invalid-charts-import/ChartsDashboard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+
+interface ChartsDashboardProps {
+  data: { name: string; x: string; y: number }[];
+}
+
+export const ChartsDashboard: React.FC<ChartsDashboardProps> = ({ data }) => (
+  <Card>
+    <CardTitle>Usage Metrics</CardTitle>
+    <CardBody>
+      <Chart
+        themeColor={ChartThemeColor.blue}
+        height={250}
+        width={600}
+        padding={{ bottom: 50, left: 50, right: 50, top: 20 }}
+      >
+        <ChartGroup>
+          <ChartBar data={data} />
+        </ChartGroup>
+      </Chart>
+    </CardBody>
+  </Card>
+);

--- a/eval/pf-import-checker/cases/invalid-charts-import/annotations.yaml
+++ b/eval/pf-import-checker/cases/invalid-charts-import/annotations.yaml
@@ -1,0 +1,4 @@
+expect_violations: true
+violation_type: charts-root-import
+invalid_import: "@patternfly/react-charts"
+correct_import: "@patternfly/react-charts/victory"

--- a/eval/pf-import-checker/cases/invalid-charts-import/input.yaml
+++ b/eval/pf-import-checker/cases/invalid-charts-import/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Check the import paths in this React component for PF6 compliance."
+fixture: ChartsDashboard.tsx

--- a/eval/pf-import-checker/cases/invalid-chatbot-import/AssistantPanel.tsx
+++ b/eval/pf-import-checker/cases/invalid-chatbot-import/AssistantPanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Chatbot, ChatbotContent, ChatbotFooter, MessageBox } from '@patternfly/chatbot';
+import { Page, PageSection } from '@patternfly/react-core';
+
+interface AssistantPanelProps {
+  messages: { role: string; content: string }[];
+  onSend: (message: string) => void;
+}
+
+export const AssistantPanel: React.FC<AssistantPanelProps> = ({ messages, onSend }) => (
+  <Page>
+    <PageSection>
+      <Chatbot>
+        <ChatbotContent>
+          <MessageBox>
+            {messages.map((msg, i) => (
+              <div key={i} className={`message message--${msg.role}`}>
+                {msg.content}
+              </div>
+            ))}
+          </MessageBox>
+        </ChatbotContent>
+        <ChatbotFooter />
+      </Chatbot>
+    </PageSection>
+  </Page>
+);

--- a/eval/pf-import-checker/cases/invalid-chatbot-import/annotations.yaml
+++ b/eval/pf-import-checker/cases/invalid-chatbot-import/annotations.yaml
@@ -1,0 +1,4 @@
+expect_violations: true
+violation_type: chatbot-root-import
+invalid_import: "@patternfly/chatbot"
+correct_import: "@patternfly/chatbot/dist/dynamic"

--- a/eval/pf-import-checker/cases/invalid-chatbot-import/input.yaml
+++ b/eval/pf-import-checker/cases/invalid-chatbot-import/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Audit the imports in this file for correct PF6 import paths."
+fixture: AssistantPanel.tsx

--- a/eval/pf-import-checker/cases/valid-pf6-imports/SettingsPage.tsx
+++ b/eval/pf-import-checker/cases/valid-pf6-imports/SettingsPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Chart, ChartDonut } from '@patternfly/react-charts/victory';
+import { Chatbot, ChatbotContent } from '@patternfly/chatbot/dist/dynamic/Chatbot';
+import { MessageBox } from '@patternfly/chatbot/dist/dynamic/MessageBox';
+import { InvalidObject } from '@patternfly/react-component-groups/dist/dynamic/InvalidObject';
+import {
+  Page,
+  PageSection,
+  Card,
+  CardBody,
+  CardTitle,
+  Switch,
+  Form,
+  FormGroup,
+} from '@patternfly/react-core';
+
+interface SettingsPageProps {
+  darkMode: boolean;
+  onToggleDarkMode: (checked: boolean) => void;
+}
+
+export const SettingsPage: React.FC<SettingsPageProps> = ({
+  darkMode,
+  onToggleDarkMode,
+}) => (
+  <Page>
+    <PageSection>
+      <Card>
+        <CardTitle>Settings</CardTitle>
+        <CardBody>
+          <Form>
+            <FormGroup label="Dark Mode">
+              <Switch
+                id="dark-mode-toggle"
+                isChecked={darkMode}
+                onChange={(_event, checked) => onToggleDarkMode(checked)}
+              />
+            </FormGroup>
+          </Form>
+        </CardBody>
+      </Card>
+    </PageSection>
+  </Page>
+);

--- a/eval/pf-import-checker/cases/valid-pf6-imports/annotations.yaml
+++ b/eval/pf-import-checker/cases/valid-pf6-imports/annotations.yaml
@@ -1,0 +1,1 @@
+expect_violations: false

--- a/eval/pf-import-checker/cases/valid-pf6-imports/input.yaml
+++ b/eval/pf-import-checker/cases/valid-pf6-imports/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Verify the import paths in this component follow PF6 conventions."
+fixture: SettingsPage.tsx

--- a/eval/pf-import-checker/eval.yaml
+++ b/eval/pf-import-checker/eval.yaml
@@ -1,0 +1,97 @@
+name: pf-import-checker-eval
+description: Evaluate pf-import-checker's detection of incorrect PF6 import paths
+
+skill: react:pf-import-checker
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-6
+  judge: claude-sonnet-4-6
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: prompt field with a realistic user request
+    - annotations.yaml: expect_violations (true/false) and violation_type for conditional judges
+    - A .tsx fixture file the prompt references
+
+outputs:
+  - path: artifacts
+    schema: |
+      The skill produces a text report identifying incorrect import
+      paths and suggesting the correct PF6 subpath.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: flags_invalid_import
+    description: Identifies the incorrect import path in the fixture
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      invalid_path = annotations.get("invalid_import", "")
+      if not invalid_path:
+          return False, "Test case missing invalid_import annotation"
+      if invalid_path not in text:
+          return False, f"Did not flag the invalid import: {invalid_path}"
+      return True, f"Correctly flagged invalid import: {invalid_path}"
+
+  - name: suggests_correct_path
+    description: Recommends the correct PF6 import subpath
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      correct_path = annotations.get("correct_import", "")
+      if not correct_path:
+          return False, "Test case missing correct_import annotation"
+      if correct_path not in text:
+          return False, f"Did not suggest correct import path: {correct_path}"
+      return True, f"Correctly suggests: {correct_path}"
+
+  - name: no_false_positives
+    description: Does not flag valid PF6 imports as violations
+    if: "annotations.get('expect_violations') == False"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      valid_imports = [
+          "@patternfly/react-charts/victory",
+          "@patternfly/chatbot/dist/dynamic",
+          "@patternfly/react-component-groups/dist/dynamic",
+          "@patternfly/react-core",
+      ]
+      for imp in valid_imports:
+          pattern = re.compile(
+              r'(incorrect|invalid|wrong|deprecated|violation|replace|fix).*'
+              + re.escape(imp),
+              re.IGNORECASE
+          )
+          if pattern.search(text):
+              return False, f"False positive — flagged valid import as violation: {imp}"
+      return True, "No false positives for valid PF6 imports"
+
+thresholds:
+  flags_invalid_import:
+    min_pass_rate: 1.0
+  suggests_correct_path:
+    min_pass_rate: 1.0
+  no_false_positives:
+    min_pass_rate: 1.0

--- a/eval/pf-raw-colors-scan/cases/already-tokenized/_dashboard.scss
+++ b/eval/pf-raw-colors-scan/cases/already-tokenized/_dashboard.scss
@@ -1,0 +1,19 @@
+.app-dashboard {
+  background-color: var(--pf-t--global--background--color--primary--default);
+  color: var(--pf-t--global--text--color--regular);
+
+  &__sidebar {
+    background-color: var(--pf-t--global--background--color--secondary--default);
+    border-right: 1px solid var(--pf-t--global--border--color--default);
+  }
+
+  &__header {
+    color: var(--pf-t--global--text--color--brand--default);
+    padding: var(--pf-t--global--spacer--md);
+  }
+
+  &__alert {
+    background-color: var(--pf-t--global--background--color--danger--default);
+    color: var(--pf-t--global--text--color--on-danger--default);
+  }
+}

--- a/eval/pf-raw-colors-scan/cases/already-tokenized/annotations.yaml
+++ b/eval/pf-raw-colors-scan/cases/already-tokenized/annotations.yaml
@@ -1,0 +1,2 @@
+expect_violations: false
+case_type: already-tokenized

--- a/eval/pf-raw-colors-scan/cases/already-tokenized/input.yaml
+++ b/eval/pf-raw-colors-scan/cases/already-tokenized/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Audit this SCSS file for hardcoded color values that should use PatternFly design tokens."
+fixture: _dashboard.scss

--- a/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/_card-styles.scss
+++ b/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/_card-styles.scss
@@ -1,0 +1,25 @@
+.app-card {
+  background-color: #ffffff;
+  color: #151515;
+  border: 1px solid #d2d2d2;
+
+  &__header {
+    background-color: rgba(0, 102, 204, 0.1);
+    border-bottom: 1px solid #d2d2d2;
+  }
+
+  &__title {
+    color: #0066cc;
+    font-size: var(--pf-t--global--font--size--lg);
+  }
+
+  &__body {
+    padding: var(--pf-t--global--spacer--md);
+    color: #6a6e73;
+  }
+
+  &--danger {
+    border-color: #c9190b;
+    background-color: hsl(4, 90%, 58%, 0.05);
+  }
+}

--- a/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/annotations.yaml
+++ b/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/annotations.yaml
@@ -1,0 +1,2 @@
+expect_violations: true
+case_type: raw-colors

--- a/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/input.yaml
+++ b/eval/pf-raw-colors-scan/cases/raw-hex-in-styles/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Scan this SCSS file for any raw color values and suggest PatternFly design token replacements."
+fixture: _card-styles.scss

--- a/eval/pf-raw-colors-scan/cases/token-declaration-exception/_token-definitions.scss
+++ b/eval/pf-raw-colors-scan/cases/token-declaration-exception/_token-definitions.scss
@@ -1,0 +1,12 @@
+// Design token variable declarations — these define tokens, not consume raw colors
+$pf-color-blue-500: #0066cc;
+$pf-color-red-100: #c9190b;
+$pf-color-black-900: #151515;
+$pf-color-black-200: #f0f0f0;
+$pf-color-white: #ffffff;
+
+:root {
+  --custom-brand-primary: #{$pf-color-blue-500};
+  --custom-brand-danger: #{$pf-color-red-100};
+  --custom-text-primary: #{$pf-color-black-900};
+}

--- a/eval/pf-raw-colors-scan/cases/token-declaration-exception/annotations.yaml
+++ b/eval/pf-raw-colors-scan/cases/token-declaration-exception/annotations.yaml
@@ -1,0 +1,2 @@
+expect_violations: false
+case_type: token-declaration

--- a/eval/pf-raw-colors-scan/cases/token-declaration-exception/input.yaml
+++ b/eval/pf-raw-colors-scan/cases/token-declaration-exception/input.yaml
@@ -1,0 +1,2 @@
+prompt: "Check this SCSS file for raw color values that need to be replaced with design tokens."
+fixture: _token-definitions.scss

--- a/eval/pf-raw-colors-scan/eval.yaml
+++ b/eval/pf-raw-colors-scan/eval.yaml
@@ -1,0 +1,110 @@
+name: pf-raw-colors-scan-eval
+description: Evaluate pf-raw-colors-scan's ability to detect raw colors and suggest PF token replacements
+
+skill: design-audit:pf-raw-colors-scan
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-6
+  judge: claude-sonnet-4-6
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: prompt field with a realistic user request
+    - annotations.yaml: expect_violations (true/false) for conditional judges
+    - An SCSS or CSS fixture file the prompt references
+
+outputs:
+  - path: artifacts
+    schema: |
+      The skill produces a text report listing violations with
+      file name, line number, property, raw value, and recommendation.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: finds_raw_colors
+    description: Detects raw hex/rgb/hsl values in the fixture
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      hex_pattern = re.compile(r'#[A-Fa-f0-9]{3,8}\b')
+      rgb_pattern = re.compile(r'rgba?\(')
+      has_hex = hex_pattern.search(text)
+      has_rgb = rgb_pattern.search(text)
+      if not has_hex and not has_rgb:
+          return False, "Output doesn't reference any raw color values from the fixture"
+      return True, "Output references raw color values found in fixture"
+
+  - name: suggests_pf_tokens
+    description: Recommends PF design tokens, not generic CSS variables
+    if: "annotations.get('expect_violations') == True"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      pf_token = re.compile(r'--pf-t--')
+      generic_var = re.compile(r'var\(--(?!pf)')
+      if not pf_token.search(text):
+          return False, "No PF design token recommendations (--pf-t--) found"
+      return True, "Suggests PF design token replacements"
+
+  - name: skips_token_declarations
+    description: Does not flag colors inside token variable declarations
+    if: "annotations.get('expect_violations') == False and annotations.get('case_type') == 'token-declaration'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      fixture_colors = ["#0066cc", "#c9190b", "#151515", "#f0f0f0", "#ffffff"]
+      flagged = []
+      for color in fixture_colors:
+          pattern = re.compile(
+              r'(violation|flag|issue|problem|replace|hardcoded).*' + re.escape(color),
+              re.IGNORECASE
+          )
+          if pattern.search(text):
+              flagged.append(color)
+      if flagged:
+          return False, f"Incorrectly flagged token declaration values: {flagged}"
+      return True, "Did not flag any token declaration values as violations"
+
+  - name: clean_report
+    description: Reports no violations for already-tokenized code
+    if: "annotations.get('expect_violations') == False and annotations.get('case_type') == 'already-tokenized'"
+    check: |
+      import re
+      text = outputs.get("conversation", "")
+      false_positive = re.compile(
+          r'(violation|replace|hardcoded|raw color).*#[A-Fa-f0-9]{3,8}',
+          re.IGNORECASE
+      )
+      if false_positive.search(text):
+          return False, "False positive — flagged tokenized code as having raw color violations"
+      return True, "No false positives for already-tokenized code"
+
+thresholds:
+  finds_raw_colors:
+    min_pass_rate: 1.0
+  suggests_pf_tokens:
+    min_pass_rate: 1.0
+  skips_token_declarations:
+    min_pass_rate: 1.0
+  clean_report:
+    min_pass_rate: 1.0

--- a/plugins/migration/README.md
+++ b/plugins/migration/README.md
@@ -9,22 +9,7 @@ PF version migration — breaking change detection, class scanning, upgrade plan
 ### Skills
 
 - **PF Class Migration Scanner** (`/migration:pf-class-migration-scanner`) — Scan code for legacy PatternFly CSS classes and recommend PF6-safe replacements.
-
-**PF React Breaking Changes** (`/migration:pf-react-breaking-changes`) — Scans for `@patternfly/react-*` API breaking changes (removed props, renamed components, import path changes) and generates a markdown report.
-
-## File Structure
-
-```text
-migration/
-├── .claude-plugin/
-│   └── plugin.json
-├── .cursor-plugin/
-│   └── plugin.json
-├── skills/
-│   ├── pf-class-migration-scanner/
-│   └── pf-react-breaking-changes/
-└── README.md
-```
+- **PF React Breaking Changes** (`/migration:pf-react-breaking-changes`) — Scan code for @patternfly/react-* API breaking changes and produce a markdown report.
 
 ## Sources
 

--- a/plugins/pf-workshop/README.md
+++ b/plugins/pf-workshop/README.md
@@ -15,7 +15,7 @@ PatternFly team tools and skill incubation — issue triage, release management,
 - **Icon Finder** (`/pf-workshop:icon-finder`) — Find Red Hat Design System icons (@rhds/icons) by keyword or use case with visual previews.
 - **PF Analyze Modifiers** (`/pf-workshop:pf-analyze-modifiers`) — Analyze PatternFly modifier class (pf-m-*) usage across SCSS files and generate usage reports.
 - **PF Bug Triage** (`/pf-workshop:pf-bug-triage`) — Triage PatternFly bug reports — assess completeness, suggest fixes, identify affected components, and recommend assignees.
-- **PF Content Review** (`/pf-workshop:pf-content-review`) — Audit and rewrite content to match PatternFly and Red Hat voice and tone standards.
+- **PF Content Review** (`/pf-workshop:pf-content-review`) — Review content against PatternFly and Red Hat voice and tone standards.
 - **PF Create Issue** (`/pf-workshop:pf-create-issue`) — Create well-structured GitHub issues for PatternFly repositories with templates, follow-up tracking, and duplicate detection.
 - **PF Org Version Update** (`/pf-workshop:pf-org-version-update`) — Update patternfly-org for a new PatternFly release — resolve versions, update package.json and versions.json, and provide build steps.
 - **PF Tokens** (`/pf-workshop:pf-tokens`) — Build CSS design tokens for PatternFly core and copy them to the PatternFly repository.


### PR DESCRIPTION
## Summary

- Add eval configs and test cases for 3 scanner skills (Batch 1 of PF-4230 eval coverage plan)
- **pf-raw-colors-scan**: 3 cases — raw hex/rgb/hsl detection, token declaration exception, already-tokenized negative control
- **pf-import-checker**: 3 cases — invalid charts import, invalid chatbot import, valid PF6 imports negative control
- **pf-class-migration-scanner**: 3 cases — legacy versioned classes, legacy token patterns, valid PF6 code negative control
- All judges use deterministic `check` type (Python regex/string matching)
- Negative-control judges check for absence of violation markers (Kent's testing feedback applied)

Closes: PF-4339
Closes: PF-4346
Closes: PF-4343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new migration skill example for breaking-change detection.
  * Expanded evaluation coverage with additional PatternFly class, import, and color-check scenarios.

* **Documentation**
  * Updated skill and plugin guides to better describe content review and migration capabilities.
  * Refreshed the skills count badge to reflect the current total.

* **Bug Fixes**
  * Clarified guidance so the right plugin examples are easier to find and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->